### PR TITLE
VexRiscv_IMA: improve performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ VexRiscv_LinuxDebug.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal -d --outputFile VexRiscv_LinuxDebug"
 
 VexRiscv_IMA.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --atomics true --outputFile VexRiscv_IMA"
+	sbt compile "runMain vexriscv.GenCoreDefault --atomics true --prediction dynamic_target --dCacheSize 8192 --iCacheSize 8192 --earlyBranch true --outputFile VexRiscv_IMA"

--- a/VexRiscv_IMA.v
+++ b/VexRiscv_IMA.v
@@ -1,5 +1,5 @@
 // Generator : SpinalHDL v1.3.5    git head : f0505d24810c8661a24530409359554b7cfa271a
-// Date      : 09/07/2021, 10:47:15
+// Date      : 27/08/2021, 17:47:19
 // Component : VexRiscv
 
 
@@ -8,11 +8,11 @@
 `define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
 `define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
 
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -20,21 +20,21 @@
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
+`define EnvCtrlEnum_defaultEncoding_type [0:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 1'b0
+`define EnvCtrlEnum_defaultEncoding_XRET 1'b1
+
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
 `define BranchCtrlEnum_defaultEncoding_B 2'b01
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
-
-`define EnvCtrlEnum_defaultEncoding_type [0:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 1'b0
-`define EnvCtrlEnum_defaultEncoding_XRET 1'b1
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
 `define AluCtrlEnum_defaultEncoding_type [1:0]
 `define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
@@ -88,13 +88,13 @@ module InstructionCache (
       input   io_mem_rsp_payload_error,
       input   clk,
       input   reset);
-  reg [21:0] _zz_10_;
+  reg [20:0] _zz_10_;
   reg [31:0] _zz_11_;
   wire  _zz_12_;
   wire  _zz_13_;
   wire [0:0] _zz_14_;
   wire [0:0] _zz_15_;
-  wire [21:0] _zz_16_;
+  wire [20:0] _zz_16_;
   reg  _zz_1_;
   reg  _zz_2_;
   reg  lineLoader_fire;
@@ -102,7 +102,7 @@ module InstructionCache (
   reg [31:0] lineLoader_address;
   reg  lineLoader_hadError;
   reg  lineLoader_flushPending;
-  reg [7:0] lineLoader_flushCounter;
+  reg [8:0] lineLoader_flushCounter;
   reg  _zz_3_;
   reg  lineLoader_cmdSent;
   reg  lineLoader_wayToAllocate_willIncrement;
@@ -111,21 +111,21 @@ module InstructionCache (
   wire  lineLoader_wayToAllocate_willOverflow;
   reg [2:0] lineLoader_wordIndex;
   wire  lineLoader_write_tag_0_valid;
-  wire [6:0] lineLoader_write_tag_0_payload_address;
+  wire [7:0] lineLoader_write_tag_0_payload_address;
   wire  lineLoader_write_tag_0_payload_data_valid;
   wire  lineLoader_write_tag_0_payload_data_error;
-  wire [19:0] lineLoader_write_tag_0_payload_data_address;
+  wire [18:0] lineLoader_write_tag_0_payload_data_address;
   wire  lineLoader_write_data_0_valid;
-  wire [9:0] lineLoader_write_data_0_payload_address;
+  wire [10:0] lineLoader_write_data_0_payload_address;
   wire [31:0] lineLoader_write_data_0_payload_data;
   wire  _zz_4_;
-  wire [6:0] _zz_5_;
+  wire [7:0] _zz_5_;
   wire  _zz_6_;
   wire  fetchStage_read_waysValues_0_tag_valid;
   wire  fetchStage_read_waysValues_0_tag_error;
-  wire [19:0] fetchStage_read_waysValues_0_tag_address;
-  wire [21:0] _zz_7_;
-  wire [9:0] _zz_8_;
+  wire [18:0] fetchStage_read_waysValues_0_tag_address;
+  wire [20:0] _zz_7_;
+  wire [10:0] _zz_8_;
   wire  _zz_9_;
   wire [31:0] fetchStage_read_waysValues_0_data;
   wire  fetchStage_hit_hits_0;
@@ -143,9 +143,9 @@ module InstructionCache (
   reg  decodeStage_mmuRsp_refilling;
   reg  decodeStage_hit_valid;
   reg  decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
+  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:2047];
+  assign _zz_12_ = (! lineLoader_flushCounter[8]);
   assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign _zz_14_ = _zz_7_[0 : 0];
   assign _zz_15_ = _zz_7_[1 : 1];
@@ -225,24 +225,24 @@ module InstructionCache (
   assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
   assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
   assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[8]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[8] ? lineLoader_address[12 : 5] : lineLoader_flushCounter[7 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[8];
   assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 13];
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[12 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_5_ = io_cpu_prefetch_pc[12 : 5];
   assign _zz_6_ = (! io_cpu_fetch_isStuck);
   assign _zz_7_ = _zz_10_;
   assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
   assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[20 : 2];
+  assign _zz_8_ = io_cpu_prefetch_pc[12 : 2];
   assign _zz_9_ = (! io_cpu_fetch_isStuck);
   assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 13]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
@@ -302,11 +302,11 @@ module InstructionCache (
       lineLoader_address <= io_cpu_fill_payload;
     end
     if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + (8'b00000001));
+      lineLoader_flushCounter <= (lineLoader_flushCounter + (9'b000000001));
     end
-    _zz_3_ <= lineLoader_flushCounter[7];
+    _zz_3_ <= lineLoader_flushCounter[8];
     if(_zz_13_)begin
-      lineLoader_flushCounter <= (8'b00000000);
+      lineLoader_flushCounter <= (9'b000000000);
     end
     if((! io_cpu_decode_isStuck))begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -384,7 +384,7 @@ module DataCache (
       input   io_mem_rsp_payload_error,
       input   clk,
       input   reset);
-  reg [21:0] _zz_10_;
+  reg [20:0] _zz_10_;
   reg [31:0] _zz_11_;
   wire  _zz_12_;
   wire  _zz_13_;
@@ -411,36 +411,36 @@ module DataCache (
   wire [0:0] _zz_34_;
   wire [2:0] _zz_35_;
   wire [1:0] _zz_36_;
-  wire [21:0] _zz_37_;
+  wire [20:0] _zz_37_;
   reg  _zz_1_;
   reg  _zz_2_;
   wire  haltCpu;
   reg  tagsReadCmd_valid;
-  reg [6:0] tagsReadCmd_payload;
+  reg [7:0] tagsReadCmd_payload;
   reg  tagsWriteCmd_valid;
   reg [0:0] tagsWriteCmd_payload_way;
-  reg [6:0] tagsWriteCmd_payload_address;
+  reg [7:0] tagsWriteCmd_payload_address;
   reg  tagsWriteCmd_payload_data_valid;
   reg  tagsWriteCmd_payload_data_error;
-  reg [19:0] tagsWriteCmd_payload_data_address;
+  reg [18:0] tagsWriteCmd_payload_data_address;
   reg  tagsWriteLastCmd_valid;
   reg [0:0] tagsWriteLastCmd_payload_way;
-  reg [6:0] tagsWriteLastCmd_payload_address;
+  reg [7:0] tagsWriteLastCmd_payload_address;
   reg  tagsWriteLastCmd_payload_data_valid;
   reg  tagsWriteLastCmd_payload_data_error;
-  reg [19:0] tagsWriteLastCmd_payload_data_address;
+  reg [18:0] tagsWriteLastCmd_payload_data_address;
   reg  dataReadCmd_valid;
-  reg [9:0] dataReadCmd_payload;
+  reg [10:0] dataReadCmd_payload;
   reg  dataWriteCmd_valid;
   reg [0:0] dataWriteCmd_payload_way;
-  reg [9:0] dataWriteCmd_payload_address;
+  reg [10:0] dataWriteCmd_payload_address;
   reg [31:0] dataWriteCmd_payload_data;
   reg [3:0] dataWriteCmd_payload_mask;
   wire  _zz_3_;
   wire  ways_0_tagsReadRsp_valid;
   wire  ways_0_tagsReadRsp_error;
-  wire [19:0] ways_0_tagsReadRsp_address;
-  wire [21:0] _zz_4_;
+  wire [18:0] ways_0_tagsReadRsp_address;
+  wire [20:0] _zz_4_;
   wire  _zz_5_;
   wire [31:0] ways_0_dataReadRsp;
   reg [3:0] _zz_6_;
@@ -475,7 +475,7 @@ module DataCache (
   reg  stageB_mmuRsp_refilling;
   reg  stageB_tagsReadRsp_0_valid;
   reg  stageB_tagsReadRsp_0_error;
-  reg [19:0] stageB_tagsReadRsp_0_address;
+  reg [18:0] stageB_tagsReadRsp_0_address;
   reg [31:0] stageB_dataReadRsp_0;
   wire [0:0] _zz_8_;
   reg [0:0] stageB_waysHits;
@@ -506,11 +506,11 @@ module DataCache (
   wire  loader_counter_willOverflow;
   reg [0:0] loader_waysAllocator;
   reg  loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
   reg [7:0] _zz_38_;
   reg [7:0] _zz_39_;
   reg [7:0] _zz_40_;
@@ -599,7 +599,7 @@ module DataCache (
   assign _zz_4_ = _zz_10_;
   assign ways_0_tagsReadRsp_valid = _zz_23_[0];
   assign ways_0_tagsReadRsp_error = _zz_24_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
+  assign ways_0_tagsReadRsp_address = _zz_4_[20 : 2];
   assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRsp = _zz_11_;
   always @ (*) begin
@@ -610,9 +610,9 @@ module DataCache (
   end
 
   always @ (*) begin
-    tagsReadCmd_payload = (7'bxxxxxxx);
+    tagsReadCmd_payload = (8'bxxxxxxxx);
     if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+      tagsReadCmd_payload = io_cpu_execute_address[12 : 5];
     end
   end
 
@@ -624,9 +624,9 @@ module DataCache (
   end
 
   always @ (*) begin
-    dataReadCmd_payload = (10'bxxxxxxxxxx);
+    dataReadCmd_payload = (11'bxxxxxxxxxxx);
     if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+      dataReadCmd_payload = io_cpu_execute_address[12 : 2];
     end
   end
 
@@ -654,12 +654,12 @@ module DataCache (
   end
 
   always @ (*) begin
-    tagsWriteCmd_payload_address = (7'bxxxxxxx);
+    tagsWriteCmd_payload_address = (8'bxxxxxxxx);
     if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 5];
     end
     if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 5];
     end
   end
 
@@ -681,9 +681,9 @@ module DataCache (
   end
 
   always @ (*) begin
-    tagsWriteCmd_payload_data_address = (20'bxxxxxxxxxxxxxxxxxxxx);
+    tagsWriteCmd_payload_data_address = (19'bxxxxxxxxxxxxxxxxxxx);
     if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 13];
     end
   end
 
@@ -729,16 +729,16 @@ module DataCache (
   end
 
   always @ (*) begin
-    dataWriteCmd_payload_address = (10'bxxxxxxxxxx);
+    dataWriteCmd_payload_address = (11'bxxxxxxxxxxx);
     if(io_cpu_writeBack_isValid)begin
       if(! stageB_mmuRsp_isIoAccess) begin
         if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 2];
         end
       end
     end
     if(_zz_17_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[12 : 5],loader_counter_value};
     end
   end
 
@@ -785,14 +785,14 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
+  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[12 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
   assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
   assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
   assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
   assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
   assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
+  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 13] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[12 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
   assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
   always @ (*) begin
     stageB_mmuRspFreeze = 1'b0;
@@ -1128,14 +1128,14 @@ module DataCache (
         stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
       end
       if(stageB_flusher_valid)begin
-        if((stageB_mmuRsp_physicalAddress[11 : 5] != (7'b1111111)))begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + (7'b0000001));
+        if((stageB_mmuRsp_physicalAddress[12 : 5] != (8'b11111111)))begin
+          stageB_mmuRsp_physicalAddress[12 : 5] <= (stageB_mmuRsp_physicalAddress[12 : 5] + (8'b00000001));
         end else begin
           stageB_flusher_valid <= 1'b0;
         end
       end
       if(_zz_19_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (7'b0000000);
+        stageB_mmuRsp_physicalAddress[12 : 5] <= (8'b00000000);
         stageB_flusher_valid <= 1'b1;
       end
       if(((((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && (! io_cpu_redo)) && stageB_request_isLrsc) && (! stageB_request_wr)))begin
@@ -1196,32 +1196,33 @@ module VexRiscv (
       output [2:0] dBusWishbone_CTI,
       input   clk,
       input   reset);
-  wire  _zz_225_;
+  wire  _zz_216_;
+  wire  _zz_217_;
+  wire  _zz_218_;
+  wire  _zz_219_;
+  wire  _zz_220_;
+  wire [31:0] _zz_221_;
+  wire  _zz_222_;
+  wire  _zz_223_;
+  wire  _zz_224_;
+  reg  _zz_225_;
   wire  _zz_226_;
-  wire  _zz_227_;
-  wire  _zz_228_;
+  wire [31:0] _zz_227_;
+  reg  _zz_228_;
   wire  _zz_229_;
-  wire [31:0] _zz_230_;
+  wire [2:0] _zz_230_;
   wire  _zz_231_;
-  wire  _zz_232_;
-  wire  _zz_233_;
-  reg  _zz_234_;
+  wire [31:0] _zz_232_;
+  reg  _zz_233_;
+  wire  _zz_234_;
   wire  _zz_235_;
   wire [31:0] _zz_236_;
-  reg  _zz_237_;
+  wire  _zz_237_;
   wire  _zz_238_;
-  wire [2:0] _zz_239_;
-  wire  _zz_240_;
-  wire [31:0] _zz_241_;
-  reg  _zz_242_;
-  wire  _zz_243_;
-  wire  _zz_244_;
-  wire [31:0] _zz_245_;
-  wire  _zz_246_;
-  wire  _zz_247_;
-  reg [31:0] _zz_248_;
-  reg [31:0] _zz_249_;
-  reg [31:0] _zz_250_;
+  reg [53:0] _zz_239_;
+  reg [31:0] _zz_240_;
+  reg [31:0] _zz_241_;
+  reg [31:0] _zz_242_;
   wire  IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire [31:0] IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire [31:0] IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -1259,13 +1260,21 @@ module VexRiscv (
   wire [3:0] dataCache_1__io_mem_cmd_payload_mask;
   wire [2:0] dataCache_1__io_mem_cmd_payload_length;
   wire  dataCache_1__io_mem_cmd_payload_last;
+  wire  _zz_243_;
+  wire  _zz_244_;
+  wire  _zz_245_;
+  wire  _zz_246_;
+  wire  _zz_247_;
+  wire  _zz_248_;
+  wire  _zz_249_;
+  wire  _zz_250_;
   wire  _zz_251_;
   wire  _zz_252_;
   wire  _zz_253_;
   wire  _zz_254_;
   wire  _zz_255_;
   wire  _zz_256_;
-  wire  _zz_257_;
+  wire [1:0] _zz_257_;
   wire  _zz_258_;
   wire  _zz_259_;
   wire  _zz_260_;
@@ -1273,8 +1282,8 @@ module VexRiscv (
   wire  _zz_262_;
   wire  _zz_263_;
   wire  _zz_264_;
-  wire [1:0] _zz_265_;
-  wire  _zz_266_;
+  wire  _zz_265_;
+  wire [1:0] _zz_266_;
   wire  _zz_267_;
   wire  _zz_268_;
   wire  _zz_269_;
@@ -1284,28 +1293,28 @@ module VexRiscv (
   wire  _zz_273_;
   wire [1:0] _zz_274_;
   wire  _zz_275_;
-  wire  _zz_276_;
-  wire  _zz_277_;
-  wire  _zz_278_;
-  wire  _zz_279_;
-  wire  _zz_280_;
-  wire  _zz_281_;
-  wire [1:0] _zz_282_;
-  wire  _zz_283_;
+  wire [1:0] _zz_276_;
+  wire [3:0] _zz_277_;
+  wire [2:0] _zz_278_;
+  wire [31:0] _zz_279_;
+  wire [9:0] _zz_280_;
+  wire [19:0] _zz_281_;
+  wire [29:0] _zz_282_;
+  wire [9:0] _zz_283_;
   wire [1:0] _zz_284_;
-  wire [4:0] _zz_285_;
-  wire [2:0] _zz_286_;
-  wire [31:0] _zz_287_;
-  wire [11:0] _zz_288_;
-  wire [31:0] _zz_289_;
-  wire [19:0] _zz_290_;
-  wire [11:0] _zz_291_;
-  wire [31:0] _zz_292_;
-  wire [31:0] _zz_293_;
-  wire [19:0] _zz_294_;
-  wire [11:0] _zz_295_;
-  wire [2:0] _zz_296_;
-  wire [2:0] _zz_297_;
+  wire [0:0] _zz_285_;
+  wire [1:0] _zz_286_;
+  wire [0:0] _zz_287_;
+  wire [1:0] _zz_288_;
+  wire [1:0] _zz_289_;
+  wire [0:0] _zz_290_;
+  wire [1:0] _zz_291_;
+  wire [0:0] _zz_292_;
+  wire [1:0] _zz_293_;
+  wire [2:0] _zz_294_;
+  wire [2:0] _zz_295_;
+  wire [0:0] _zz_296_;
+  wire [0:0] _zz_297_;
   wire [0:0] _zz_298_;
   wire [0:0] _zz_299_;
   wire [0:0] _zz_300_;
@@ -1324,343 +1333,335 @@ module VexRiscv (
   wire [0:0] _zz_313_;
   wire [0:0] _zz_314_;
   wire [0:0] _zz_315_;
-  wire [0:0] _zz_316_;
-  wire [0:0] _zz_317_;
-  wire [2:0] _zz_318_;
-  wire [4:0] _zz_319_;
-  wire [11:0] _zz_320_;
-  wire [11:0] _zz_321_;
+  wire [2:0] _zz_316_;
+  wire [4:0] _zz_317_;
+  wire [11:0] _zz_318_;
+  wire [11:0] _zz_319_;
+  wire [31:0] _zz_320_;
+  wire [31:0] _zz_321_;
   wire [31:0] _zz_322_;
   wire [31:0] _zz_323_;
   wire [31:0] _zz_324_;
   wire [31:0] _zz_325_;
   wire [31:0] _zz_326_;
-  wire [31:0] _zz_327_;
+  wire [32:0] _zz_327_;
   wire [31:0] _zz_328_;
   wire [32:0] _zz_329_;
-  wire [31:0] _zz_330_;
-  wire [32:0] _zz_331_;
+  wire [19:0] _zz_330_;
+  wire [11:0] _zz_331_;
   wire [11:0] _zz_332_;
-  wire [19:0] _zz_333_;
-  wire [11:0] _zz_334_;
-  wire [31:0] _zz_335_;
-  wire [31:0] _zz_336_;
-  wire [31:0] _zz_337_;
-  wire [11:0] _zz_338_;
-  wire [19:0] _zz_339_;
-  wire [11:0] _zz_340_;
-  wire [2:0] _zz_341_;
-  wire [1:0] _zz_342_;
-  wire [1:0] _zz_343_;
-  wire [51:0] _zz_344_;
-  wire [51:0] _zz_345_;
-  wire [51:0] _zz_346_;
-  wire [32:0] _zz_347_;
-  wire [51:0] _zz_348_;
-  wire [49:0] _zz_349_;
-  wire [51:0] _zz_350_;
-  wire [49:0] _zz_351_;
-  wire [51:0] _zz_352_;
-  wire [65:0] _zz_353_;
-  wire [65:0] _zz_354_;
-  wire [31:0] _zz_355_;
-  wire [31:0] _zz_356_;
+  wire [1:0] _zz_333_;
+  wire [1:0] _zz_334_;
+  wire [51:0] _zz_335_;
+  wire [51:0] _zz_336_;
+  wire [51:0] _zz_337_;
+  wire [32:0] _zz_338_;
+  wire [51:0] _zz_339_;
+  wire [49:0] _zz_340_;
+  wire [51:0] _zz_341_;
+  wire [49:0] _zz_342_;
+  wire [51:0] _zz_343_;
+  wire [65:0] _zz_344_;
+  wire [65:0] _zz_345_;
+  wire [31:0] _zz_346_;
+  wire [31:0] _zz_347_;
+  wire [0:0] _zz_348_;
+  wire [5:0] _zz_349_;
+  wire [32:0] _zz_350_;
+  wire [32:0] _zz_351_;
+  wire [31:0] _zz_352_;
+  wire [31:0] _zz_353_;
+  wire [32:0] _zz_354_;
+  wire [32:0] _zz_355_;
+  wire [32:0] _zz_356_;
   wire [0:0] _zz_357_;
-  wire [5:0] _zz_358_;
-  wire [32:0] _zz_359_;
+  wire [32:0] _zz_358_;
+  wire [0:0] _zz_359_;
   wire [32:0] _zz_360_;
-  wire [31:0] _zz_361_;
+  wire [0:0] _zz_361_;
   wire [31:0] _zz_362_;
-  wire [32:0] _zz_363_;
-  wire [32:0] _zz_364_;
-  wire [32:0] _zz_365_;
+  wire [0:0] _zz_363_;
+  wire [0:0] _zz_364_;
+  wire [0:0] _zz_365_;
   wire [0:0] _zz_366_;
-  wire [32:0] _zz_367_;
+  wire [0:0] _zz_367_;
   wire [0:0] _zz_368_;
-  wire [32:0] _zz_369_;
-  wire [0:0] _zz_370_;
-  wire [31:0] _zz_371_;
-  wire [0:0] _zz_372_;
-  wire [0:0] _zz_373_;
-  wire [0:0] _zz_374_;
+  wire [26:0] _zz_369_;
+  wire [53:0] _zz_370_;
+  wire  _zz_371_;
+  wire  _zz_372_;
+  wire [1:0] _zz_373_;
+  wire [31:0] _zz_374_;
   wire [0:0] _zz_375_;
-  wire [0:0] _zz_376_;
+  wire [4:0] _zz_376_;
   wire [0:0] _zz_377_;
-  wire [26:0] _zz_378_;
-  wire  _zz_379_;
-  wire  _zz_380_;
-  wire [2:0] _zz_381_;
-  wire  _zz_382_;
-  wire  _zz_383_;
-  wire  _zz_384_;
-  wire  _zz_385_;
-  wire [0:0] _zz_386_;
-  wire [1:0] _zz_387_;
-  wire  _zz_388_;
-  wire [0:0] _zz_389_;
-  wire [1:0] _zz_390_;
-  wire [0:0] _zz_391_;
+  wire [2:0] _zz_378_;
+  wire [1:0] _zz_379_;
+  wire [1:0] _zz_380_;
+  wire  _zz_381_;
+  wire [0:0] _zz_382_;
+  wire [26:0] _zz_383_;
+  wire [31:0] _zz_384_;
+  wire [31:0] _zz_385_;
+  wire  _zz_386_;
+  wire [0:0] _zz_387_;
+  wire [2:0] _zz_388_;
+  wire [31:0] _zz_389_;
+  wire [31:0] _zz_390_;
+  wire  _zz_391_;
   wire [0:0] _zz_392_;
-  wire [1:0] _zz_393_;
-  wire [1:0] _zz_394_;
+  wire [0:0] _zz_393_;
+  wire  _zz_394_;
   wire  _zz_395_;
   wire [0:0] _zz_396_;
-  wire [26:0] _zz_397_;
-  wire [31:0] _zz_398_;
-  wire [31:0] _zz_399_;
-  wire [31:0] _zz_400_;
-  wire  _zz_401_;
-  wire  _zz_402_;
+  wire [1:0] _zz_397_;
+  wire [1:0] _zz_398_;
+  wire [1:0] _zz_399_;
+  wire  _zz_400_;
+  wire [0:0] _zz_401_;
+  wire [24:0] _zz_402_;
   wire [31:0] _zz_403_;
   wire [31:0] _zz_404_;
   wire [31:0] _zz_405_;
   wire  _zz_406_;
-  wire  _zz_407_;
-  wire [31:0] _zz_408_;
+  wire [0:0] _zz_407_;
+  wire [0:0] _zz_408_;
   wire [31:0] _zz_409_;
-  wire  _zz_410_;
-  wire  _zz_411_;
-  wire  _zz_412_;
-  wire [0:0] _zz_413_;
-  wire [0:0] _zz_414_;
-  wire  _zz_415_;
-  wire [0:0] _zz_416_;
-  wire [24:0] _zz_417_;
-  wire [31:0] _zz_418_;
-  wire [31:0] _zz_419_;
-  wire [31:0] _zz_420_;
-  wire [31:0] _zz_421_;
-  wire [31:0] _zz_422_;
-  wire [31:0] _zz_423_;
-  wire [31:0] _zz_424_;
-  wire [31:0] _zz_425_;
-  wire [31:0] _zz_426_;
-  wire  _zz_427_;
-  wire [0:0] _zz_428_;
-  wire [0:0] _zz_429_;
-  wire  _zz_430_;
-  wire [0:0] _zz_431_;
-  wire [22:0] _zz_432_;
+  wire [31:0] _zz_410_;
+  wire [31:0] _zz_411_;
+  wire [31:0] _zz_412_;
+  wire [31:0] _zz_413_;
+  wire [31:0] _zz_414_;
+  wire [31:0] _zz_415_;
+  wire [31:0] _zz_416_;
+  wire [31:0] _zz_417_;
+  wire  _zz_418_;
+  wire  _zz_419_;
+  wire  _zz_420_;
+  wire  _zz_421_;
+  wire [0:0] _zz_422_;
+  wire [0:0] _zz_423_;
+  wire  _zz_424_;
+  wire [0:0] _zz_425_;
+  wire [22:0] _zz_426_;
+  wire [31:0] _zz_427_;
+  wire [31:0] _zz_428_;
+  wire [31:0] _zz_429_;
+  wire [31:0] _zz_430_;
+  wire [31:0] _zz_431_;
+  wire [31:0] _zz_432_;
   wire [31:0] _zz_433_;
   wire [31:0] _zz_434_;
-  wire  _zz_435_;
+  wire [31:0] _zz_435_;
   wire  _zz_436_;
-  wire  _zz_437_;
-  wire  _zz_438_;
-  wire [0:0] _zz_439_;
+  wire [0:0] _zz_437_;
+  wire [0:0] _zz_438_;
+  wire  _zz_439_;
   wire [0:0] _zz_440_;
-  wire  _zz_441_;
-  wire [0:0] _zz_442_;
-  wire [18:0] _zz_443_;
-  wire [31:0] _zz_444_;
-  wire [31:0] _zz_445_;
-  wire [31:0] _zz_446_;
-  wire [0:0] _zz_447_;
-  wire [0:0] _zz_448_;
-  wire  _zz_449_;
+  wire [20:0] _zz_441_;
+  wire  _zz_442_;
+  wire [0:0] _zz_443_;
+  wire [1:0] _zz_444_;
+  wire  _zz_445_;
+  wire [0:0] _zz_446_;
+  wire [2:0] _zz_447_;
+  wire  _zz_448_;
+  wire [0:0] _zz_449_;
   wire [0:0] _zz_450_;
-  wire [15:0] _zz_451_;
-  wire [31:0] _zz_452_;
-  wire [31:0] _zz_453_;
+  wire  _zz_451_;
+  wire [0:0] _zz_452_;
+  wire [16:0] _zz_453_;
   wire [31:0] _zz_454_;
-  wire  _zz_455_;
-  wire [4:0] _zz_456_;
-  wire [4:0] _zz_457_;
+  wire [31:0] _zz_455_;
+  wire [31:0] _zz_456_;
+  wire  _zz_457_;
   wire  _zz_458_;
-  wire [0:0] _zz_459_;
-  wire [11:0] _zz_460_;
+  wire [31:0] _zz_459_;
+  wire [31:0] _zz_460_;
   wire [31:0] _zz_461_;
-  wire [31:0] _zz_462_;
-  wire  _zz_463_;
+  wire  _zz_462_;
+  wire [0:0] _zz_463_;
   wire [0:0] _zz_464_;
-  wire [1:0] _zz_465_;
-  wire [0:0] _zz_466_;
-  wire [0:0] _zz_467_;
+  wire [31:0] _zz_465_;
+  wire [31:0] _zz_466_;
+  wire [31:0] _zz_467_;
   wire [0:0] _zz_468_;
-  wire [0:0] _zz_469_;
-  wire [0:0] _zz_470_;
-  wire [0:0] _zz_471_;
+  wire [1:0] _zz_469_;
+  wire [2:0] _zz_470_;
+  wire [2:0] _zz_471_;
   wire  _zz_472_;
   wire [0:0] _zz_473_;
-  wire [8:0] _zz_474_;
+  wire [14:0] _zz_474_;
   wire [31:0] _zz_475_;
   wire [31:0] _zz_476_;
   wire [31:0] _zz_477_;
   wire [31:0] _zz_478_;
   wire [31:0] _zz_479_;
-  wire  _zz_480_;
-  wire [0:0] _zz_481_;
-  wire [2:0] _zz_482_;
-  wire [0:0] _zz_483_;
-  wire [0:0] _zz_484_;
-  wire [1:0] _zz_485_;
-  wire [1:0] _zz_486_;
-  wire  _zz_487_;
+  wire [31:0] _zz_480_;
+  wire [31:0] _zz_481_;
+  wire  _zz_482_;
+  wire  _zz_483_;
+  wire  _zz_484_;
+  wire [0:0] _zz_485_;
+  wire [0:0] _zz_486_;
+  wire [0:0] _zz_487_;
   wire [0:0] _zz_488_;
-  wire [5:0] _zz_489_;
-  wire [31:0] _zz_490_;
-  wire [31:0] _zz_491_;
-  wire [31:0] _zz_492_;
-  wire  _zz_493_;
-  wire [0:0] _zz_494_;
-  wire [0:0] _zz_495_;
+  wire [1:0] _zz_489_;
+  wire [1:0] _zz_490_;
+  wire  _zz_491_;
+  wire [0:0] _zz_492_;
+  wire [12:0] _zz_493_;
+  wire [31:0] _zz_494_;
+  wire [31:0] _zz_495_;
   wire [31:0] _zz_496_;
   wire [31:0] _zz_497_;
-  wire  _zz_498_;
-  wire [0:0] _zz_499_;
-  wire [1:0] _zz_500_;
-  wire [0:0] _zz_501_;
-  wire [0:0] _zz_502_;
+  wire [31:0] _zz_498_;
+  wire [31:0] _zz_499_;
+  wire [31:0] _zz_500_;
+  wire [31:0] _zz_501_;
+  wire [31:0] _zz_502_;
   wire  _zz_503_;
   wire [0:0] _zz_504_;
-  wire [3:0] _zz_505_;
-  wire [31:0] _zz_506_;
-  wire [31:0] _zz_507_;
-  wire [31:0] _zz_508_;
-  wire [31:0] _zz_509_;
-  wire [31:0] _zz_510_;
+  wire [1:0] _zz_505_;
+  wire [1:0] _zz_506_;
+  wire [1:0] _zz_507_;
+  wire  _zz_508_;
+  wire [0:0] _zz_509_;
+  wire [10:0] _zz_510_;
   wire [31:0] _zz_511_;
-  wire  _zz_512_;
-  wire  _zz_513_;
+  wire [31:0] _zz_512_;
+  wire [31:0] _zz_513_;
   wire [31:0] _zz_514_;
   wire [31:0] _zz_515_;
-  wire [0:0] _zz_516_;
-  wire [5:0] _zz_517_;
-  wire [1:0] _zz_518_;
-  wire [1:0] _zz_519_;
+  wire [31:0] _zz_516_;
+  wire  _zz_517_;
+  wire [0:0] _zz_518_;
+  wire [0:0] _zz_519_;
   wire  _zz_520_;
   wire [0:0] _zz_521_;
-  wire [1:0] _zz_522_;
+  wire [7:0] _zz_522_;
   wire [31:0] _zz_523_;
-  wire [31:0] _zz_524_;
+  wire  _zz_524_;
   wire  _zz_525_;
-  wire [0:0] _zz_526_;
-  wire [2:0] _zz_527_;
-  wire [31:0] _zz_528_;
-  wire [31:0] _zz_529_;
-  wire [31:0] _zz_530_;
+  wire [4:0] _zz_526_;
+  wire [4:0] _zz_527_;
+  wire  _zz_528_;
+  wire [0:0] _zz_529_;
+  wire [3:0] _zz_530_;
   wire [31:0] _zz_531_;
-  wire  _zz_532_;
+  wire [31:0] _zz_532_;
   wire  _zz_533_;
   wire [0:0] _zz_534_;
   wire [1:0] _zz_535_;
   wire [0:0] _zz_536_;
   wire [0:0] _zz_537_;
-  wire [3:0] _zz_538_;
-  wire [3:0] _zz_539_;
-  wire [31:0] _zz_540_;
-  wire [31:0] _zz_541_;
-  wire [31:0] _zz_542_;
-  wire  _zz_543_;
-  wire [0:0] _zz_544_;
-  wire [0:0] _zz_545_;
+  wire [0:0] _zz_538_;
+  wire [0:0] _zz_539_;
+  wire  _zz_540_;
+  wire [0:0] _zz_541_;
+  wire [0:0] _zz_542_;
+  wire [31:0] _zz_543_;
+  wire [31:0] _zz_544_;
+  wire [31:0] _zz_545_;
   wire [31:0] _zz_546_;
   wire [31:0] _zz_547_;
   wire [31:0] _zz_548_;
   wire [31:0] _zz_549_;
-  wire  _zz_550_;
-  wire  _zz_551_;
-  wire [31:0] _zz_552_;
-  wire [31:0] _zz_553_;
-  wire  _zz_554_;
-  wire [0:0] _zz_555_;
-  wire [1:0] _zz_556_;
-  wire [31:0] _zz_557_;
-  wire [31:0] _zz_558_;
-  wire [31:0] _zz_559_;
+  wire [0:0] _zz_550_;
+  wire [2:0] _zz_551_;
+  wire [0:0] _zz_552_;
+  wire [0:0] _zz_553_;
+  wire [31:0] _zz_554_;
+  wire [31:0] _zz_555_;
+  wire [31:0] _zz_556_;
+  wire  _zz_557_;
+  wire [0:0] _zz_558_;
+  wire [14:0] _zz_559_;
   wire [31:0] _zz_560_;
   wire [31:0] _zz_561_;
   wire [31:0] _zz_562_;
-  wire [31:0] _zz_563_;
-  wire [31:0] _zz_564_;
-  wire [31:0] _zz_565_;
-  wire  _zz_566_;
-  wire [0:0] _zz_567_;
-  wire [14:0] _zz_568_;
-  wire [31:0] _zz_569_;
-  wire [31:0] _zz_570_;
-  wire [31:0] _zz_571_;
-  wire  _zz_572_;
-  wire [0:0] _zz_573_;
-  wire [8:0] _zz_574_;
-  wire [31:0] _zz_575_;
-  wire [31:0] _zz_576_;
-  wire [31:0] _zz_577_;
-  wire  _zz_578_;
-  wire [0:0] _zz_579_;
-  wire [2:0] _zz_580_;
-  wire  _zz_581_;
-  wire  _zz_582_;
-  wire  _zz_583_;
-  wire  decode_MEMORY_AMO;
-  wire  decode_MEMORY_LRSC;
-  wire [1:0] memory_MEMORY_ADDRESS_LOW;
-  wire [1:0] execute_MEMORY_ADDRESS_LOW;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_1_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_2_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_3_;
+  wire  _zz_563_;
+  wire [0:0] _zz_564_;
+  wire [8:0] _zz_565_;
+  wire [31:0] _zz_566_;
+  wire [31:0] _zz_567_;
+  wire [31:0] _zz_568_;
+  wire  _zz_569_;
+  wire [0:0] _zz_570_;
+  wire [2:0] _zz_571_;
   wire  memory_IS_MUL;
   wire  execute_IS_MUL;
   wire  decode_IS_MUL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_4_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_5_;
-  wire `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_6_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_7_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_8_;
-  wire  memory_MEMORY_WR;
-  wire  decode_MEMORY_WR;
-  wire `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_9_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_10_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_11_;
-  wire [31:0] execute_MUL_LL;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_12_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_13_;
-  wire [33:0] execute_MUL_HL;
-  wire [31:0] execute_SHIFT_RIGHT;
-  wire [33:0] memory_MUL_HH;
-  wire [33:0] execute_MUL_HH;
-  wire  execute_BRANCH_DO;
-  wire  decode_IS_DIV;
-  wire  decode_BYPASSABLE_EXECUTE_STAGE;
-  wire  decode_CSR_READ_OPCODE;
-  wire  decode_MEMORY_MANAGMENT;
-  wire `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_14_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_15_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_16_;
-  wire [31:0] memory_PC;
-  wire [51:0] memory_MUL_LOW;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_17_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_18_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_19_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_20_;
-  wire `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_21_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_22_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_23_;
-  wire [33:0] execute_MUL_LH;
-  wire  decode_CSR_WRITE_OPCODE;
   wire [31:0] writeBack_FORMAL_PC_NEXT;
   wire [31:0] memory_FORMAL_PC_NEXT;
   wire [31:0] execute_FORMAL_PC_NEXT;
   wire [31:0] decode_FORMAL_PC_NEXT;
-  wire  decode_SRC_LESS_UNSIGNED;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_1_;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_2_;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_3_;
+  wire `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire `Src1CtrlEnum_defaultEncoding_type _zz_4_;
+  wire `Src1CtrlEnum_defaultEncoding_type _zz_5_;
+  wire `Src1CtrlEnum_defaultEncoding_type _zz_6_;
+  wire [51:0] memory_MUL_LOW;
+  wire  decode_MEMORY_LRSC;
+  wire  decode_IS_RS1_SIGNED;
+  wire  decode_CSR_WRITE_OPCODE;
+  wire  decode_SRC2_FORCE_ZERO;
+  wire [33:0] execute_MUL_LH;
+  wire [31:0] execute_MUL_LL;
+  wire  decode_CSR_READ_OPCODE;
+  wire  decode_MEMORY_AMO;
+  wire [33:0] execute_MUL_HL;
   wire  execute_BYPASSABLE_MEMORY_STAGE;
   wire  decode_BYPASSABLE_MEMORY_STAGE;
-  wire [31:0] execute_REGFILE_WRITE_DATA;
+  wire  decode_MEMORY_MANAGMENT;
+  wire `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire `Src2CtrlEnum_defaultEncoding_type _zz_7_;
+  wire `Src2CtrlEnum_defaultEncoding_type _zz_8_;
+  wire `Src2CtrlEnum_defaultEncoding_type _zz_9_;
+  wire  decode_IS_DIV;
+  wire [31:0] memory_PC;
+  wire  decode_BYPASSABLE_EXECUTE_STAGE;
+  wire  memory_MEMORY_WR;
+  wire  decode_MEMORY_WR;
+  wire [33:0] memory_MUL_HH;
+  wire [33:0] execute_MUL_HH;
+  wire [31:0] execute_SHIFT_RIGHT;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_10_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_11_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_12_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_13_;
+  wire `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_14_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_15_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_16_;
+  wire `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
+  wire `BranchCtrlEnum_defaultEncoding_type _zz_17_;
+  wire `BranchCtrlEnum_defaultEncoding_type _zz_18_;
+  wire `BranchCtrlEnum_defaultEncoding_type _zz_19_;
   wire  decode_IS_CSR;
-  wire [31:0] execute_BRANCH_CALC;
-  wire  decode_IS_RS1_SIGNED;
-  wire  decode_PREDICTION_HAD_BRANCHED2;
-  wire  decode_SRC2_FORCE_ZERO;
+  wire [1:0] memory_MEMORY_ADDRESS_LOW;
+  wire [1:0] execute_MEMORY_ADDRESS_LOW;
+  wire  decode_PREDICTION_CONTEXT_hazard;
+  wire  decode_PREDICTION_CONTEXT_hit;
+  wire [19:0] decode_PREDICTION_CONTEXT_line_source;
+  wire [1:0] decode_PREDICTION_CONTEXT_line_branchWish;
+  wire [31:0] decode_PREDICTION_CONTEXT_line_target;
+  wire [31:0] execute_REGFILE_WRITE_DATA;
   wire  decode_IS_RS2_SIGNED;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_20_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_21_;
+  wire `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_22_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_23_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_24_;
+  wire  decode_SRC_LESS_UNSIGNED;
   wire `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_24_;
   wire `AluCtrlEnum_defaultEncoding_type _zz_25_;
   wire `AluCtrlEnum_defaultEncoding_type _zz_26_;
+  wire `AluCtrlEnum_defaultEncoding_type _zz_27_;
   wire  execute_IS_RS1_SIGNED;
   wire  execute_IS_DIV;
   wire  execute_IS_RS2_SIGNED;
@@ -1671,37 +1672,37 @@ module VexRiscv (
   wire [33:0] memory_MUL_HL;
   wire [33:0] memory_MUL_LH;
   wire [31:0] memory_MUL_LL;
-  wire [51:0] _zz_27_;
-  wire [33:0] _zz_28_;
+  wire [51:0] _zz_28_;
   wire [33:0] _zz_29_;
   wire [33:0] _zz_30_;
-  wire [31:0] _zz_31_;
+  wire [33:0] _zz_31_;
+  wire [31:0] _zz_32_;
   wire  execute_CSR_READ_OPCODE;
   wire  execute_CSR_WRITE_OPCODE;
   wire  execute_IS_CSR;
   wire `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_32_;
-  wire `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
   wire `EnvCtrlEnum_defaultEncoding_type _zz_33_;
-  wire  _zz_34_;
+  wire `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_34_;
   wire  _zz_35_;
+  wire  _zz_36_;
   wire `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_36_;
-  wire [31:0] memory_BRANCH_CALC;
-  wire  memory_BRANCH_DO;
-  wire [31:0] _zz_37_;
-  wire [31:0] execute_PC;
-  wire  execute_PREDICTION_HAD_BRANCHED2;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_37_;
+  wire [31:0] execute_NEXT_PC2;
+  wire  execute_TARGET_MISSMATCH2;
+  wire  execute_BRANCH_DO;
+  wire [31:0] execute_BRANCH_CALC;
   wire  _zz_38_;
+  wire [31:0] _zz_39_;
+  wire [31:0] _zz_40_;
+  wire [31:0] execute_PC;
   wire [31:0] execute_RS1;
-  wire  execute_BRANCH_COND_RESULT;
   wire `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_39_;
-  wire  _zz_40_;
-  wire  _zz_41_;
+  wire `BranchCtrlEnum_defaultEncoding_type _zz_41_;
+  wire  _zz_42_;
   wire  decode_RS2_USE;
   wire  decode_RS1_USE;
-  reg [31:0] _zz_42_;
+  reg [31:0] _zz_43_;
   wire  execute_REGFILE_WRITE_VALID;
   wire  execute_BYPASSABLE_EXECUTE_STAGE;
   wire  memory_REGFILE_WRITE_VALID;
@@ -1711,81 +1712,81 @@ module VexRiscv (
   reg [31:0] decode_RS2;
   reg [31:0] decode_RS1;
   wire [31:0] memory_SHIFT_RIGHT;
-  reg [31:0] _zz_43_;
+  reg [31:0] _zz_44_;
   wire `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_44_;
-  wire [31:0] _zz_45_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_45_;
+  wire [31:0] _zz_46_;
   wire `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_46_;
-  wire  _zz_47_;
-  wire [31:0] _zz_48_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_47_;
+  wire  _zz_48_;
   wire [31:0] _zz_49_;
+  wire [31:0] _zz_50_;
   wire  execute_SRC_LESS_UNSIGNED;
   wire  execute_SRC2_FORCE_ZERO;
   wire  execute_SRC_USE_SUB_LESS;
-  wire [31:0] _zz_50_;
+  wire [31:0] _zz_51_;
   wire `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_51_;
-  wire [31:0] _zz_52_;
+  wire `Src2CtrlEnum_defaultEncoding_type _zz_52_;
+  wire [31:0] _zz_53_;
   wire `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_53_;
-  wire [31:0] _zz_54_;
+  wire `Src1CtrlEnum_defaultEncoding_type _zz_54_;
+  wire [31:0] _zz_55_;
   wire  decode_SRC_USE_SUB_LESS;
   wire  decode_SRC_ADD_ZERO;
-  wire  _zz_55_;
+  wire  _zz_56_;
   wire [31:0] execute_SRC_ADD_SUB;
   wire  execute_SRC_LESS;
   wire `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_56_;
-  wire [31:0] _zz_57_;
+  wire `AluCtrlEnum_defaultEncoding_type _zz_57_;
+  wire [31:0] _zz_58_;
   wire [31:0] execute_SRC2;
   wire [31:0] execute_SRC1;
   wire `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_58_;
-  wire [31:0] _zz_59_;
-  wire  _zz_60_;
-  reg  _zz_61_;
-  wire [31:0] _zz_62_;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_59_;
+  wire [31:0] _zz_60_;
+  wire  _zz_61_;
+  reg  _zz_62_;
   wire [31:0] _zz_63_;
+  wire [31:0] _zz_64_;
   wire [31:0] decode_INSTRUCTION_ANTICIPATED;
   reg  decode_REGFILE_WRITE_VALID;
   wire  decode_LEGAL_INSTRUCTION;
   wire  decode_INSTRUCTION_READY;
-  wire  _zz_64_;
   wire  _zz_65_;
   wire  _zz_66_;
-  wire  _zz_67_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_68_;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_69_;
-  wire  _zz_70_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_71_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_67_;
+  wire  _zz_68_;
+  wire  _zz_69_;
+  wire `AluCtrlEnum_defaultEncoding_type _zz_70_;
+  wire  _zz_71_;
   wire  _zz_72_;
   wire  _zz_73_;
-  wire  _zz_74_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_74_;
   wire  _zz_75_;
   wire  _zz_76_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_77_;
-  wire  _zz_78_;
+  wire  _zz_77_;
+  wire `Src2CtrlEnum_defaultEncoding_type _zz_78_;
   wire `Src1CtrlEnum_defaultEncoding_type _zz_79_;
   wire  _zz_80_;
   wire  _zz_81_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_82_;
+  wire  _zz_82_;
   wire  _zz_83_;
-  wire  _zz_84_;
+  wire `BranchCtrlEnum_defaultEncoding_type _zz_84_;
   wire  _zz_85_;
   wire  _zz_86_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_87_;
-  wire  _zz_88_;
+  wire  _zz_87_;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_88_;
   wire  _zz_89_;
   wire  _zz_90_;
-  reg [31:0] _zz_91_;
+  wire  _zz_91_;
+  reg [31:0] _zz_92_;
   wire [1:0] writeBack_MEMORY_ADDRESS_LOW;
   wire  writeBack_MEMORY_WR;
   wire [31:0] writeBack_REGFILE_WRITE_DATA;
   wire  writeBack_MEMORY_ENABLE;
   wire [31:0] memory_REGFILE_WRITE_DATA;
   wire  memory_MEMORY_ENABLE;
-  wire [1:0] _zz_92_;
+  wire [1:0] _zz_93_;
   wire  execute_MEMORY_AMO;
   wire  execute_MEMORY_LRSC;
   wire  execute_MEMORY_MANAGMENT;
@@ -1797,25 +1798,34 @@ module VexRiscv (
   wire  decode_MEMORY_ENABLE;
   wire  decode_FLUSH_ALL;
   reg  IBusCachedPlugin_rsp_issueDetected;
-  reg  _zz_93_;
   reg  _zz_94_;
   reg  _zz_95_;
-  wire [31:0] _zz_96_;
-  wire `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_97_;
+  reg  _zz_96_;
   wire [31:0] decode_INSTRUCTION;
-  reg [31:0] _zz_98_;
-  reg [31:0] _zz_99_;
-  wire [31:0] decode_PC;
-  wire [31:0] _zz_100_;
-  wire [31:0] _zz_101_;
+  wire [31:0] _zz_97_;
+  wire  execute_PREDICTION_CONTEXT_hazard;
+  wire  execute_PREDICTION_CONTEXT_hit;
+  wire [19:0] execute_PREDICTION_CONTEXT_line_source;
+  wire [1:0] execute_PREDICTION_CONTEXT_line_branchWish;
+  wire [31:0] execute_PREDICTION_CONTEXT_line_target;
+  wire  _zz_98_;
+  wire  _zz_99_;
+  wire [19:0] _zz_100_;
+  wire [1:0] _zz_101_;
   wire [31:0] _zz_102_;
+  reg  _zz_103_;
+  reg [31:0] _zz_104_;
+  reg [31:0] _zz_105_;
+  wire [31:0] decode_PC;
+  wire [31:0] _zz_106_;
+  wire [31:0] _zz_107_;
+  wire [31:0] _zz_108_;
   wire [31:0] writeBack_PC;
   wire [31:0] writeBack_INSTRUCTION;
   reg  decode_arbitration_haltItself;
   reg  decode_arbitration_haltByOther;
   reg  decode_arbitration_removeIt;
-  wire  decode_arbitration_flushAll;
+  reg  decode_arbitration_flushAll;
   wire  decode_arbitration_isValid;
   wire  decode_arbitration_isStuck;
   wire  decode_arbitration_isStuckByOthers;
@@ -1825,7 +1835,7 @@ module VexRiscv (
   reg  execute_arbitration_haltItself;
   wire  execute_arbitration_haltByOther;
   reg  execute_arbitration_removeIt;
-  reg  execute_arbitration_flushAll;
+  wire  execute_arbitration_flushAll;
   reg  execute_arbitration_isValid;
   wire  execute_arbitration_isStuck;
   wire  execute_arbitration_isStuckByOthers;
@@ -1859,10 +1869,11 @@ module VexRiscv (
   reg  IBusCachedPlugin_fetcherHalt;
   wire  IBusCachedPlugin_fetcherflushIt;
   reg  IBusCachedPlugin_incomingInstruction;
-  wire  IBusCachedPlugin_predictionJumpInterface_valid;
-  (* keep , syn_keep *) wire [31:0] IBusCachedPlugin_pcs_4 /* synthesis syn_keep = 1 */ ;
-  reg  IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  wire  IBusCachedPlugin_decodePrediction_rsp_wasWrong;
+  wire  IBusCachedPlugin_fetchPrediction_cmd_hadBranch;
+  wire [31:0] IBusCachedPlugin_fetchPrediction_cmd_targetPc;
+  wire  IBusCachedPlugin_fetchPrediction_rsp_wasRight;
+  wire [31:0] IBusCachedPlugin_fetchPrediction_rsp_finalPc;
+  wire [31:0] IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord;
   wire  IBusCachedPlugin_pcValids_0;
   wire  IBusCachedPlugin_pcValids_1;
   wire  IBusCachedPlugin_pcValids_2;
@@ -1906,7 +1917,7 @@ module VexRiscv (
   wire [31:0] decodeExceptionPort_payload_badAddr;
   wire  BranchPlugin_jumpInterface_valid;
   wire [31:0] BranchPlugin_jumpInterface_payload;
-  wire  BranchPlugin_branchExceptionPort_valid;
+  reg  BranchPlugin_branchExceptionPort_valid;
   wire [3:0] BranchPlugin_branchExceptionPort_payload_code;
   wire [31:0] BranchPlugin_branchExceptionPort_payload_badAddr;
   reg  CsrPlugin_jumpInterface_valid;
@@ -1923,25 +1934,26 @@ module VexRiscv (
   wire  CsrPlugin_allowException;
   wire  IBusCachedPlugin_jump_pcLoad_valid;
   wire [31:0] IBusCachedPlugin_jump_pcLoad_payload;
-  wire [4:0] _zz_103_;
-  wire [4:0] _zz_104_;
-  wire  _zz_105_;
-  wire  _zz_106_;
-  wire  _zz_107_;
-  wire  _zz_108_;
+  wire [3:0] _zz_109_;
+  wire [3:0] _zz_110_;
+  wire  _zz_111_;
+  wire  _zz_112_;
+  wire  _zz_113_;
   wire  IBusCachedPlugin_fetchPc_preOutput_valid;
   wire  IBusCachedPlugin_fetchPc_preOutput_ready;
   wire [31:0] IBusCachedPlugin_fetchPc_preOutput_payload;
-  wire  _zz_109_;
+  wire  _zz_114_;
   wire  IBusCachedPlugin_fetchPc_output_valid;
   wire  IBusCachedPlugin_fetchPc_output_ready;
   wire [31:0] IBusCachedPlugin_fetchPc_output_payload;
+  wire  IBusCachedPlugin_fetchPc_predictionPcLoad_valid;
+  wire [31:0] IBusCachedPlugin_fetchPc_predictionPcLoad_payload;
   reg [31:0] IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg  IBusCachedPlugin_fetchPc_inc;
   reg  IBusCachedPlugin_fetchPc_propagatePc;
   reg [31:0] IBusCachedPlugin_fetchPc_pc;
   reg  IBusCachedPlugin_fetchPc_samplePcNext;
-  reg  _zz_110_;
+  reg  _zz_115_;
   wire  IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire  IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   wire [31:0] IBusCachedPlugin_iBusRsp_stages_0_input_payload;
@@ -1966,15 +1978,15 @@ module VexRiscv (
   wire [31:0] IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_payload;
   reg  IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt;
   wire  IBusCachedPlugin_iBusRsp_cacheRspArbitration_inputSample;
-  wire  _zz_111_;
-  wire  _zz_112_;
-  wire  _zz_113_;
-  wire  _zz_114_;
-  wire  _zz_115_;
-  reg  _zz_116_;
+  wire  _zz_116_;
   wire  _zz_117_;
-  reg  _zz_118_;
-  reg [31:0] _zz_119_;
+  wire  _zz_118_;
+  wire  _zz_119_;
+  wire  _zz_120_;
+  reg  _zz_121_;
+  wire  _zz_122_;
+  reg  _zz_123_;
+  reg [31:0] _zz_124_;
   reg  IBusCachedPlugin_iBusRsp_readyForError;
   wire  IBusCachedPlugin_iBusRsp_decodeInput_valid;
   wire  IBusCachedPlugin_iBusRsp_decodeInput_ready;
@@ -1988,17 +2000,39 @@ module VexRiscv (
   reg  IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg  IBusCachedPlugin_injector_nextPcCalc_valids_4;
   reg  IBusCachedPlugin_injector_decodeRemoved;
-  wire  _zz_120_;
-  reg [18:0] _zz_121_;
-  wire  _zz_122_;
-  reg [10:0] _zz_123_;
-  wire  _zz_124_;
-  reg [18:0] _zz_125_;
-  reg  _zz_126_;
-  wire  _zz_127_;
-  reg [10:0] _zz_128_;
-  wire  _zz_129_;
-  reg [18:0] _zz_130_;
+  reg  IBusCachedPlugin_predictor_historyWrite_valid;
+  wire [9:0] IBusCachedPlugin_predictor_historyWrite_payload_address;
+  wire [19:0] IBusCachedPlugin_predictor_historyWrite_payload_data_source;
+  reg [1:0] IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
+  wire [31:0] IBusCachedPlugin_predictor_historyWrite_payload_data_target;
+  wire [29:0] _zz_125_;
+  wire  _zz_126_;
+  wire [19:0] IBusCachedPlugin_predictor_line_source;
+  wire [1:0] IBusCachedPlugin_predictor_line_branchWish;
+  wire [31:0] IBusCachedPlugin_predictor_line_target;
+  wire [53:0] _zz_127_;
+  wire  IBusCachedPlugin_predictor_hit;
+  reg  IBusCachedPlugin_predictor_historyWriteLast_valid;
+  reg [9:0] IBusCachedPlugin_predictor_historyWriteLast_payload_address;
+  reg [19:0] IBusCachedPlugin_predictor_historyWriteLast_payload_data_source;
+  reg [1:0] IBusCachedPlugin_predictor_historyWriteLast_payload_data_branchWish;
+  reg [31:0] IBusCachedPlugin_predictor_historyWriteLast_payload_data_target;
+  wire  IBusCachedPlugin_predictor_hazard;
+  wire  IBusCachedPlugin_predictor_fetchContext_hazard;
+  wire  IBusCachedPlugin_predictor_fetchContext_hit;
+  wire [19:0] IBusCachedPlugin_predictor_fetchContext_line_source;
+  wire [1:0] IBusCachedPlugin_predictor_fetchContext_line_branchWish;
+  wire [31:0] IBusCachedPlugin_predictor_fetchContext_line_target;
+  reg  IBusCachedPlugin_predictor_fetchContext_regNextWhen_hazard;
+  reg  IBusCachedPlugin_predictor_fetchContext_regNextWhen_hit;
+  reg [19:0] IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_source;
+  reg [1:0] IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_branchWish;
+  reg [31:0] IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_target;
+  wire  IBusCachedPlugin_predictor_injectorContext_hazard;
+  wire  IBusCachedPlugin_predictor_injectorContext_hit;
+  wire [19:0] IBusCachedPlugin_predictor_injectorContext_line_source;
+  wire [1:0] IBusCachedPlugin_predictor_injectorContext_line_branchWish;
+  wire [31:0] IBusCachedPlugin_predictor_injectorContext_line_target;
   wire  iBus_cmd_valid;
   wire  iBus_cmd_ready;
   reg [31:0] iBus_cmd_payload_address;
@@ -2030,13 +2064,13 @@ module VexRiscv (
   wire [3:0] dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
   wire [2:0] dataCache_1__io_mem_cmd_s2mPipe_payload_length;
   wire  dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg  _zz_131_;
-  reg  _zz_132_;
-  reg [31:0] _zz_133_;
-  reg [31:0] _zz_134_;
-  reg [3:0] _zz_135_;
-  reg [2:0] _zz_136_;
-  reg  _zz_137_;
+  reg  _zz_128_;
+  reg  _zz_129_;
+  reg [31:0] _zz_130_;
+  reg [31:0] _zz_131_;
+  reg [3:0] _zz_132_;
+  reg [2:0] _zz_133_;
+  reg  _zz_134_;
   wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -2045,35 +2079,35 @@ module VexRiscv (
   wire [3:0] dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   wire [2:0] dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
   wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg  _zz_138_;
-  reg  _zz_139_;
-  reg [31:0] _zz_140_;
-  reg [31:0] _zz_141_;
-  reg [3:0] _zz_142_;
-  reg [2:0] _zz_143_;
-  reg  _zz_144_;
+  reg  _zz_135_;
+  reg  _zz_136_;
+  reg [31:0] _zz_137_;
+  reg [31:0] _zz_138_;
+  reg [3:0] _zz_139_;
+  reg [2:0] _zz_140_;
+  reg  _zz_141_;
   wire [1:0] execute_DBusCachedPlugin_size;
-  reg [31:0] _zz_145_;
+  reg [31:0] _zz_142_;
   reg [31:0] writeBack_DBusCachedPlugin_rspShifted;
-  wire  _zz_146_;
-  reg [31:0] _zz_147_;
-  wire  _zz_148_;
-  reg [31:0] _zz_149_;
+  wire  _zz_143_;
+  reg [31:0] _zz_144_;
+  wire  _zz_145_;
+  reg [31:0] _zz_146_;
   reg [31:0] writeBack_DBusCachedPlugin_rspFormated;
-  wire [32:0] _zz_150_;
+  wire [32:0] _zz_147_;
+  wire  _zz_148_;
+  wire  _zz_149_;
+  wire  _zz_150_;
   wire  _zz_151_;
   wire  _zz_152_;
   wire  _zz_153_;
-  wire  _zz_154_;
-  wire  _zz_155_;
-  wire  _zz_156_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_157_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_158_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_159_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_160_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_161_;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_162_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_163_;
+  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_154_;
+  wire `BranchCtrlEnum_defaultEncoding_type _zz_155_;
+  wire `Src1CtrlEnum_defaultEncoding_type _zz_156_;
+  wire `Src2CtrlEnum_defaultEncoding_type _zz_157_;
+  wire `EnvCtrlEnum_defaultEncoding_type _zz_158_;
+  wire `AluCtrlEnum_defaultEncoding_type _zz_159_;
+  wire `ShiftCtrlEnum_defaultEncoding_type _zz_160_;
   wire [4:0] decode_RegFilePlugin_regFileReadAddress1;
   wire [4:0] decode_RegFilePlugin_regFileReadAddress2;
   wire [31:0] decode_RegFilePlugin_rs1Data;
@@ -2081,54 +2115,48 @@ module VexRiscv (
   reg  lastStageRegFileWrite_valid /* verilator public */ ;
   wire [4:0] lastStageRegFileWrite_payload_address /* verilator public */ ;
   wire [31:0] lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg  _zz_164_;
+  reg  _zz_161_;
   reg [31:0] execute_IntAluPlugin_bitwise;
-  reg [31:0] _zz_165_;
-  reg [31:0] _zz_166_;
-  wire  _zz_167_;
-  reg [19:0] _zz_168_;
-  wire  _zz_169_;
-  reg [19:0] _zz_170_;
-  reg [31:0] _zz_171_;
+  reg [31:0] _zz_162_;
+  reg [31:0] _zz_163_;
+  wire  _zz_164_;
+  reg [19:0] _zz_165_;
+  wire  _zz_166_;
+  reg [19:0] _zz_167_;
+  reg [31:0] _zz_168_;
   reg [31:0] execute_SrcPlugin_addSub;
   wire  execute_SrcPlugin_less;
   wire [4:0] execute_FullBarrelShifterPlugin_amplitude;
-  reg [31:0] _zz_172_;
+  reg [31:0] _zz_169_;
   wire [31:0] execute_FullBarrelShifterPlugin_reversed;
-  reg [31:0] _zz_173_;
+  reg [31:0] _zz_170_;
+  reg  _zz_171_;
+  reg  _zz_172_;
+  wire  _zz_173_;
   reg  _zz_174_;
-  reg  _zz_175_;
-  wire  _zz_176_;
-  reg  _zz_177_;
-  reg [4:0] _zz_178_;
-  reg [31:0] _zz_179_;
+  reg [4:0] _zz_175_;
+  reg [31:0] _zz_176_;
+  wire  _zz_177_;
+  wire  _zz_178_;
+  wire  _zz_179_;
   wire  _zz_180_;
   wire  _zz_181_;
   wire  _zz_182_;
-  wire  _zz_183_;
-  wire  _zz_184_;
-  wire  _zz_185_;
   wire  execute_BranchPlugin_eq;
-  wire [2:0] _zz_186_;
-  reg  _zz_187_;
-  reg  _zz_188_;
-  wire  _zz_189_;
-  reg [19:0] _zz_190_;
-  wire  _zz_191_;
-  reg [10:0] _zz_192_;
-  wire  _zz_193_;
-  reg [18:0] _zz_194_;
-  reg  _zz_195_;
-  wire  execute_BranchPlugin_missAlignedTarget;
-  reg [31:0] execute_BranchPlugin_branch_src1;
-  reg [31:0] execute_BranchPlugin_branch_src2;
-  wire  _zz_196_;
-  reg [19:0] _zz_197_;
-  wire  _zz_198_;
-  reg [10:0] _zz_199_;
-  wire  _zz_200_;
-  reg [18:0] _zz_201_;
+  wire [2:0] _zz_183_;
+  reg  _zz_184_;
+  reg  _zz_185_;
+  wire [31:0] execute_BranchPlugin_branch_src1;
+  wire  _zz_186_;
+  reg [10:0] _zz_187_;
+  wire  _zz_188_;
+  reg [19:0] _zz_189_;
+  wire  _zz_190_;
+  reg [18:0] _zz_191_;
+  reg [31:0] _zz_192_;
+  wire [31:0] execute_BranchPlugin_branch_src2;
   wire [31:0] execute_BranchPlugin_branchAdder;
+  wire  execute_BranchPlugin_predictionMissmatch;
   wire [1:0] CsrPlugin_misa_base;
   wire [25:0] CsrPlugin_misa_extensions;
   reg [1:0] CsrPlugin_mtvec_mode;
@@ -2148,9 +2176,9 @@ module VexRiscv (
   reg [31:0] CsrPlugin_mtval;
   reg [63:0] CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg [63:0] CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire  _zz_202_;
-  wire  _zz_203_;
-  wire  _zz_204_;
+  wire  _zz_193_;
+  wire  _zz_194_;
+  wire  _zz_195_;
   reg  CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg  CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg  CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2163,8 +2191,8 @@ module VexRiscv (
   reg [31:0] CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire [1:0] CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire [1:0] CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire [1:0] _zz_205_;
-  wire  _zz_206_;
+  wire [1:0] _zz_196_;
+  wire  _zz_197_;
   reg  CsrPlugin_interrupt_valid;
   reg [3:0] CsrPlugin_interrupt_code /* verilator public */ ;
   reg [1:0] CsrPlugin_interrupt_targetPrivilege;
@@ -2213,535 +2241,546 @@ module VexRiscv (
   wire  memory_DivPlugin_div_counter_willOverflow;
   reg  memory_DivPlugin_div_done;
   reg [31:0] memory_DivPlugin_div_result;
-  wire [31:0] _zz_207_;
-  wire [32:0] _zz_208_;
-  wire [32:0] _zz_209_;
-  wire [31:0] _zz_210_;
-  wire  _zz_211_;
-  wire  _zz_212_;
-  reg [32:0] _zz_213_;
+  wire [31:0] _zz_198_;
+  wire [32:0] _zz_199_;
+  wire [32:0] _zz_200_;
+  wire [31:0] _zz_201_;
+  wire  _zz_202_;
+  wire  _zz_203_;
+  reg [32:0] _zz_204_;
   reg [31:0] externalInterruptArray_regNext;
-  reg [31:0] _zz_214_;
-  wire [31:0] _zz_215_;
+  reg [31:0] _zz_205_;
+  wire [31:0] _zz_206_;
   reg `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg [31:0] decode_to_execute_RS1;
+  reg  decode_to_execute_SRC_LESS_UNSIGNED;
+  reg `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
   reg  decode_to_execute_IS_RS2_SIGNED;
-  reg  decode_to_execute_REGFILE_WRITE_VALID;
-  reg  execute_to_memory_REGFILE_WRITE_VALID;
-  reg  memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg  decode_to_execute_SRC2_FORCE_ZERO;
-  reg  decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg  decode_to_execute_IS_RS1_SIGNED;
-  reg [31:0] execute_to_memory_BRANCH_CALC;
-  reg  decode_to_execute_SRC_USE_SUB_LESS;
-  reg  decode_to_execute_IS_CSR;
   reg [31:0] execute_to_memory_REGFILE_WRITE_DATA;
   reg [31:0] memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg  decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg  execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg  decode_to_execute_SRC_LESS_UNSIGNED;
-  reg  decode_to_execute_MEMORY_ENABLE;
-  reg  execute_to_memory_MEMORY_ENABLE;
-  reg  memory_to_writeBack_MEMORY_ENABLE;
-  reg [31:0] decode_to_execute_FORMAL_PC_NEXT;
-  reg [31:0] execute_to_memory_FORMAL_PC_NEXT;
-  reg [31:0] memory_to_writeBack_FORMAL_PC_NEXT;
-  reg  decode_to_execute_CSR_WRITE_OPCODE;
-  reg [33:0] execute_to_memory_MUL_LH;
+  reg  decode_to_execute_PREDICTION_CONTEXT_hazard;
+  reg  decode_to_execute_PREDICTION_CONTEXT_hit;
+  reg [19:0] decode_to_execute_PREDICTION_CONTEXT_line_source;
+  reg [1:0] decode_to_execute_PREDICTION_CONTEXT_line_branchWish;
+  reg [31:0] decode_to_execute_PREDICTION_CONTEXT_line_target;
+  reg [1:0] execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg [1:0] memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg  decode_to_execute_IS_CSR;
+  reg `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
   reg `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
   reg `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg [51:0] memory_to_writeBack_MUL_LOW;
-  reg [31:0] decode_to_execute_PC;
-  reg [31:0] execute_to_memory_PC;
-  reg [31:0] memory_to_writeBack_PC;
-  reg `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg  decode_to_execute_MEMORY_MANAGMENT;
-  reg  decode_to_execute_CSR_READ_OPCODE;
-  reg  decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg  decode_to_execute_IS_DIV;
-  reg  execute_to_memory_IS_DIV;
-  reg  execute_to_memory_BRANCH_DO;
+  reg [31:0] execute_to_memory_SHIFT_RIGHT;
+  reg  decode_to_execute_MEMORY_ENABLE;
+  reg  execute_to_memory_MEMORY_ENABLE;
+  reg  memory_to_writeBack_MEMORY_ENABLE;
+  reg  decode_to_execute_REGFILE_WRITE_VALID;
+  reg  execute_to_memory_REGFILE_WRITE_VALID;
+  reg  memory_to_writeBack_REGFILE_WRITE_VALID;
   reg [33:0] execute_to_memory_MUL_HH;
   reg [33:0] memory_to_writeBack_MUL_HH;
-  reg [31:0] decode_to_execute_INSTRUCTION;
-  reg [31:0] execute_to_memory_INSTRUCTION;
-  reg [31:0] memory_to_writeBack_INSTRUCTION;
-  reg [31:0] execute_to_memory_SHIFT_RIGHT;
-  reg [33:0] execute_to_memory_MUL_HL;
-  reg `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg [31:0] execute_to_memory_MUL_LL;
-  reg `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg  decode_to_execute_SRC_USE_SUB_LESS;
   reg  decode_to_execute_MEMORY_WR;
   reg  execute_to_memory_MEMORY_WR;
   reg  memory_to_writeBack_MEMORY_WR;
-  reg [31:0] decode_to_execute_RS1;
-  reg `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg  decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg [31:0] decode_to_execute_PC;
+  reg [31:0] execute_to_memory_PC;
+  reg [31:0] memory_to_writeBack_PC;
+  reg [31:0] decode_to_execute_RS2;
+  reg  decode_to_execute_IS_DIV;
+  reg  execute_to_memory_IS_DIV;
+  reg `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg  decode_to_execute_MEMORY_MANAGMENT;
+  reg  decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg  execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg [33:0] execute_to_memory_MUL_HL;
+  reg  decode_to_execute_MEMORY_AMO;
+  reg  decode_to_execute_CSR_READ_OPCODE;
+  reg [31:0] execute_to_memory_MUL_LL;
+  reg [33:0] execute_to_memory_MUL_LH;
+  reg  decode_to_execute_SRC2_FORCE_ZERO;
+  reg  decode_to_execute_CSR_WRITE_OPCODE;
+  reg  decode_to_execute_IS_RS1_SIGNED;
+  reg  decode_to_execute_MEMORY_LRSC;
+  reg [51:0] memory_to_writeBack_MUL_LOW;
+  reg `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg [31:0] decode_to_execute_INSTRUCTION;
+  reg [31:0] execute_to_memory_INSTRUCTION;
+  reg [31:0] memory_to_writeBack_INSTRUCTION;
+  reg `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg [31:0] decode_to_execute_FORMAL_PC_NEXT;
+  reg [31:0] execute_to_memory_FORMAL_PC_NEXT;
+  reg [31:0] memory_to_writeBack_FORMAL_PC_NEXT;
   reg  decode_to_execute_IS_MUL;
   reg  execute_to_memory_IS_MUL;
   reg  memory_to_writeBack_IS_MUL;
-  reg `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg [1:0] execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg [1:0] memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg [31:0] decode_to_execute_RS2;
-  reg  decode_to_execute_MEMORY_LRSC;
-  reg  decode_to_execute_MEMORY_AMO;
-  reg [2:0] _zz_216_;
-  reg  _zz_217_;
+  reg [2:0] _zz_207_;
+  reg  _zz_208_;
   reg [31:0] iBusWishbone_DAT_MISO_regNext;
-  reg [2:0] _zz_218_;
-  wire  _zz_219_;
-  wire  _zz_220_;
-  wire  _zz_221_;
-  wire  _zz_222_;
-  wire  _zz_223_;
-  reg  _zz_224_;
+  reg [2:0] _zz_209_;
+  wire  _zz_210_;
+  wire  _zz_211_;
+  wire  _zz_212_;
+  wire  _zz_213_;
+  wire  _zz_214_;
+  reg  _zz_215_;
   reg [31:0] dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
   reg [39:0] _zz_1__string;
   reg [39:0] _zz_2__string;
   reg [39:0] _zz_3__string;
-  reg [71:0] _zz_4__string;
-  reg [71:0] _zz_5__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_6__string;
-  reg [71:0] _zz_7__string;
-  reg [71:0] _zz_8__string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_4__string;
+  reg [95:0] _zz_5__string;
+  reg [95:0] _zz_6__string;
   reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_7__string;
+  reg [23:0] _zz_8__string;
   reg [23:0] _zz_9__string;
-  reg [23:0] _zz_10__string;
-  reg [23:0] _zz_11__string;
+  reg [31:0] _zz_10__string;
+  reg [31:0] _zz_11__string;
   reg [31:0] _zz_12__string;
   reg [31:0] _zz_13__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_14__string;
-  reg [95:0] _zz_15__string;
-  reg [95:0] _zz_16__string;
+  reg [31:0] decode_ENV_CTRL_string;
+  reg [31:0] _zz_14__string;
+  reg [31:0] _zz_15__string;
+  reg [31:0] _zz_16__string;
+  reg [31:0] decode_BRANCH_CTRL_string;
   reg [31:0] _zz_17__string;
   reg [31:0] _zz_18__string;
   reg [31:0] _zz_19__string;
-  reg [31:0] _zz_20__string;
-  reg [31:0] decode_ENV_CTRL_string;
-  reg [31:0] _zz_21__string;
-  reg [31:0] _zz_22__string;
-  reg [31:0] _zz_23__string;
+  reg [71:0] _zz_20__string;
+  reg [71:0] _zz_21__string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_22__string;
+  reg [71:0] _zz_23__string;
+  reg [71:0] _zz_24__string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_24__string;
   reg [63:0] _zz_25__string;
   reg [63:0] _zz_26__string;
+  reg [63:0] _zz_27__string;
   reg [31:0] memory_ENV_CTRL_string;
-  reg [31:0] _zz_32__string;
-  reg [31:0] execute_ENV_CTRL_string;
   reg [31:0] _zz_33__string;
+  reg [31:0] execute_ENV_CTRL_string;
+  reg [31:0] _zz_34__string;
   reg [31:0] writeBack_ENV_CTRL_string;
-  reg [31:0] _zz_36__string;
+  reg [31:0] _zz_37__string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_39__string;
+  reg [31:0] _zz_41__string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_44__string;
+  reg [71:0] _zz_45__string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_46__string;
+  reg [71:0] _zz_47__string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_51__string;
+  reg [23:0] _zz_52__string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_53__string;
+  reg [95:0] _zz_54__string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_56__string;
+  reg [63:0] _zz_57__string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_58__string;
-  reg [31:0] _zz_68__string;
-  reg [63:0] _zz_69__string;
-  reg [31:0] _zz_71__string;
-  reg [39:0] _zz_77__string;
+  reg [39:0] _zz_59__string;
+  reg [71:0] _zz_67__string;
+  reg [63:0] _zz_70__string;
+  reg [31:0] _zz_74__string;
+  reg [23:0] _zz_78__string;
   reg [95:0] _zz_79__string;
-  reg [23:0] _zz_82__string;
-  reg [71:0] _zz_87__string;
-  reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_97__string;
-  reg [71:0] _zz_157__string;
-  reg [23:0] _zz_158__string;
-  reg [95:0] _zz_159__string;
-  reg [39:0] _zz_160__string;
-  reg [31:0] _zz_161__string;
-  reg [63:0] _zz_162__string;
-  reg [31:0] _zz_163__string;
+  reg [31:0] _zz_84__string;
+  reg [39:0] _zz_88__string;
+  reg [39:0] _zz_154__string;
+  reg [31:0] _zz_155__string;
+  reg [95:0] _zz_156__string;
+  reg [23:0] _zz_157__string;
+  reg [31:0] _zz_158__string;
+  reg [63:0] _zz_159__string;
+  reg [71:0] _zz_160__string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [31:0] decode_to_execute_ENV_CTRL_string;
   reg [31:0] execute_to_memory_ENV_CTRL_string;
   reg [31:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   `endif
 
+  (* ram_style = "block" *) reg [53:0] IBusCachedPlugin_predictor_history [0:1023];
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
-  assign _zz_251_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_252_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_253_ = 1'b1;
-  assign _zz_254_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_255_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_256_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_257_ = ((_zz_231_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_93_));
-  assign _zz_258_ = ((_zz_231_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_94_));
-  assign _zz_259_ = ((_zz_231_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_95_));
-  assign _zz_260_ = ((_zz_231_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! 1'b0));
-  assign _zz_261_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_262_ = (! memory_DivPlugin_div_done);
-  assign _zz_263_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_264_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_265_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_266_ = (IBusCachedPlugin_fetchPc_preOutput_valid && IBusCachedPlugin_fetchPc_preOutput_ready);
-  assign _zz_267_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_268_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_269_ = (1'b0 || (! 1'b1));
-  assign _zz_270_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_271_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_272_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_273_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_274_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_275_ = (! memory_arbitration_isStuck);
-  assign _zz_276_ = (iBus_cmd_valid || (_zz_216_ != (3'b000)));
-  assign _zz_277_ = (_zz_247_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_278_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_279_ = ((_zz_202_ && 1'b1) && (! 1'b0));
-  assign _zz_280_ = ((_zz_203_ && 1'b1) && (! 1'b0));
-  assign _zz_281_ = ((_zz_204_ && 1'b1) && (! 1'b0));
-  assign _zz_282_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_283_ = execute_INSTRUCTION[13];
-  assign _zz_284_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_285_ = (_zz_103_ - (5'b00001));
-  assign _zz_286_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_287_ = {29'd0, _zz_286_};
-  assign _zz_288_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_289_ = {{_zz_121_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_290_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_291_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_292_ = {{_zz_123_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_293_ = {{_zz_125_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_294_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_295_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_296_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_297_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_298_ = _zz_150_[0 : 0];
-  assign _zz_299_ = _zz_150_[1 : 1];
-  assign _zz_300_ = _zz_150_[4 : 4];
-  assign _zz_301_ = _zz_150_[5 : 5];
-  assign _zz_302_ = _zz_150_[6 : 6];
-  assign _zz_303_ = _zz_150_[7 : 7];
-  assign _zz_304_ = _zz_150_[10 : 10];
-  assign _zz_305_ = _zz_150_[11 : 11];
-  assign _zz_306_ = _zz_150_[14 : 14];
-  assign _zz_307_ = _zz_150_[17 : 17];
-  assign _zz_308_ = _zz_150_[18 : 18];
-  assign _zz_309_ = _zz_150_[19 : 19];
-  assign _zz_310_ = _zz_150_[20 : 20];
-  assign _zz_311_ = _zz_150_[21 : 21];
-  assign _zz_312_ = _zz_150_[24 : 24];
-  assign _zz_313_ = _zz_150_[28 : 28];
-  assign _zz_314_ = _zz_150_[29 : 29];
-  assign _zz_315_ = _zz_150_[30 : 30];
-  assign _zz_316_ = _zz_150_[32 : 32];
-  assign _zz_317_ = execute_SRC_LESS;
-  assign _zz_318_ = (3'b100);
-  assign _zz_319_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_320_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_321_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_322_ = ($signed(_zz_323_) + $signed(_zz_326_));
-  assign _zz_323_ = ($signed(_zz_324_) + $signed(_zz_325_));
-  assign _zz_324_ = execute_SRC1;
-  assign _zz_325_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_326_ = (execute_SRC_USE_SUB_LESS ? _zz_327_ : _zz_328_);
-  assign _zz_327_ = (32'b00000000000000000000000000000001);
-  assign _zz_328_ = (32'b00000000000000000000000000000000);
-  assign _zz_329_ = ($signed(_zz_331_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_330_ = _zz_329_[31 : 0];
-  assign _zz_331_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_332_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_333_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_334_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_335_ = {_zz_190_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_336_ = {{_zz_192_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_337_ = {{_zz_194_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_338_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_339_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_340_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_341_ = (3'b100);
-  assign _zz_342_ = (_zz_205_ & (~ _zz_343_));
-  assign _zz_343_ = (_zz_205_ - (2'b01));
-  assign _zz_344_ = ($signed(_zz_345_) + $signed(_zz_350_));
-  assign _zz_345_ = ($signed(_zz_346_) + $signed(_zz_348_));
-  assign _zz_346_ = (52'b0000000000000000000000000000000000000000000000000000);
-  assign _zz_347_ = {1'b0,memory_MUL_LL};
-  assign _zz_348_ = {{19{_zz_347_[32]}}, _zz_347_};
-  assign _zz_349_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_350_ = {{2{_zz_349_[49]}}, _zz_349_};
-  assign _zz_351_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_352_ = {{2{_zz_351_[49]}}, _zz_351_};
-  assign _zz_353_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_354_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_355_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_356_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_357_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_358_ = {5'd0, _zz_357_};
-  assign _zz_359_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_360_ = {_zz_207_,(! _zz_209_[32])};
-  assign _zz_361_ = _zz_209_[31:0];
-  assign _zz_362_ = _zz_208_[31:0];
-  assign _zz_363_ = _zz_364_;
-  assign _zz_364_ = _zz_365_;
-  assign _zz_365_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_210_) : _zz_210_)} + _zz_367_);
-  assign _zz_366_ = memory_DivPlugin_div_needRevert;
-  assign _zz_367_ = {32'd0, _zz_366_};
-  assign _zz_368_ = _zz_212_;
-  assign _zz_369_ = {32'd0, _zz_368_};
-  assign _zz_370_ = _zz_211_;
-  assign _zz_371_ = {31'd0, _zz_370_};
-  assign _zz_372_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_373_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_374_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_375_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_376_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_377_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_378_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_379_ = 1'b1;
-  assign _zz_380_ = 1'b1;
-  assign _zz_381_ = {_zz_106_,{_zz_108_,_zz_107_}};
-  assign _zz_382_ = decode_INSTRUCTION[31];
-  assign _zz_383_ = decode_INSTRUCTION[31];
-  assign _zz_384_ = decode_INSTRUCTION[7];
-  assign _zz_385_ = ((decode_INSTRUCTION & _zz_398_) == (32'b00000000000000000010000000010000));
-  assign _zz_386_ = (_zz_399_ == _zz_400_);
-  assign _zz_387_ = {_zz_401_,_zz_402_};
-  assign _zz_388_ = ((decode_INSTRUCTION & _zz_403_) == (32'b00000000000000000000000001000000));
-  assign _zz_389_ = (_zz_404_ == _zz_405_);
-  assign _zz_390_ = {_zz_406_,_zz_407_};
-  assign _zz_391_ = _zz_154_;
-  assign _zz_392_ = (_zz_408_ == _zz_409_);
-  assign _zz_393_ = {_zz_410_,_zz_411_};
-  assign _zz_394_ = (2'b00);
-  assign _zz_395_ = (_zz_412_ != (1'b0));
-  assign _zz_396_ = (_zz_413_ != _zz_414_);
-  assign _zz_397_ = {_zz_415_,{_zz_416_,_zz_417_}};
-  assign _zz_398_ = (32'b00000000000000000010000000110000);
-  assign _zz_399_ = (decode_INSTRUCTION & (32'b00000000000000000001000000110000));
-  assign _zz_400_ = (32'b00000000000000000000000000010000);
-  assign _zz_401_ = ((decode_INSTRUCTION & _zz_418_) == (32'b00000000000000000000000000100000));
-  assign _zz_402_ = ((decode_INSTRUCTION & _zz_419_) == (32'b00000000000000000010000000100000));
-  assign _zz_403_ = (32'b00000000000000000000000001010000);
-  assign _zz_404_ = (decode_INSTRUCTION & (32'b00000000000000000011000001000000));
-  assign _zz_405_ = (32'b00000000000000000000000001000000);
-  assign _zz_406_ = ((decode_INSTRUCTION & _zz_420_) == (32'b00000000000000000000000000000000));
-  assign _zz_407_ = ((decode_INSTRUCTION & _zz_421_) == (32'b00010000000000000010000000001000));
-  assign _zz_408_ = (decode_INSTRUCTION & (32'b00000000000000000000000001011000));
-  assign _zz_409_ = (32'b00000000000000000000000000000000);
-  assign _zz_410_ = ((decode_INSTRUCTION & _zz_422_) == (32'b00000000000000000001000001010000));
-  assign _zz_411_ = ((decode_INSTRUCTION & _zz_423_) == (32'b00000000000000000010000001010000));
-  assign _zz_412_ = ((decode_INSTRUCTION & _zz_424_) == (32'b00000010000000000000000000110000));
-  assign _zz_413_ = (_zz_425_ == _zz_426_);
-  assign _zz_414_ = (1'b0);
-  assign _zz_415_ = (_zz_427_ != (1'b0));
-  assign _zz_416_ = (_zz_428_ != _zz_429_);
-  assign _zz_417_ = {_zz_430_,{_zz_431_,_zz_432_}};
-  assign _zz_418_ = (32'b00000010000000000011000000100000);
-  assign _zz_419_ = (32'b00000010000000000010000001101000);
-  assign _zz_420_ = (32'b00000000000000000000000000111000);
-  assign _zz_421_ = (32'b00011000000000000010000000001000);
-  assign _zz_422_ = (32'b00000000000000000001000001010000);
-  assign _zz_423_ = (32'b00000000000000000010000001010000);
-  assign _zz_424_ = (32'b00000010000000000100000001110100);
-  assign _zz_425_ = (decode_INSTRUCTION & (32'b00000000000000000011000001010000));
-  assign _zz_426_ = (32'b00000000000000000000000001010000);
-  assign _zz_427_ = ((decode_INSTRUCTION & (32'b00000000000000000100000000010100)) == (32'b00000000000000000100000000010000));
-  assign _zz_428_ = ((decode_INSTRUCTION & (32'b00000000000000000110000000010100)) == (32'b00000000000000000010000000010000));
-  assign _zz_429_ = (1'b0);
-  assign _zz_430_ = ({(_zz_433_ == _zz_434_),{_zz_435_,_zz_436_}} != (3'b000));
-  assign _zz_431_ = ({_zz_152_,_zz_437_} != (2'b00));
-  assign _zz_432_ = {(_zz_438_ != (1'b0)),{(_zz_439_ != _zz_440_),{_zz_441_,{_zz_442_,_zz_443_}}}};
-  assign _zz_433_ = (decode_INSTRUCTION & (32'b00001000000000000000000000100000));
-  assign _zz_434_ = (32'b00001000000000000000000000100000);
-  assign _zz_435_ = ((decode_INSTRUCTION & (32'b00010000000000000000000000100000)) == (32'b00000000000000000000000000100000));
-  assign _zz_436_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000101000)) == (32'b00000000000000000000000000100000));
-  assign _zz_437_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000011100)) == (32'b00000000000000000000000000000100));
-  assign _zz_438_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001011000)) == (32'b00000000000000000000000001000000));
-  assign _zz_439_ = ((decode_INSTRUCTION & _zz_444_) == (32'b00010000000000000000000000001000));
-  assign _zz_440_ = (1'b0);
-  assign _zz_441_ = ((_zz_445_ == _zz_446_) != (1'b0));
-  assign _zz_442_ = (_zz_155_ != (1'b0));
-  assign _zz_443_ = {(_zz_447_ != _zz_448_),{_zz_449_,{_zz_450_,_zz_451_}}};
-  assign _zz_444_ = (32'b00010000000000000000000000001000);
-  assign _zz_445_ = (decode_INSTRUCTION & (32'b00010000000000000000000000001000));
-  assign _zz_446_ = (32'b00000000000000000000000000001000);
-  assign _zz_447_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001100100)) == (32'b00000000000000000000000000100100));
-  assign _zz_448_ = (1'b0);
-  assign _zz_449_ = (((decode_INSTRUCTION & _zz_452_) == (32'b00000010000000000100000000100000)) != (1'b0));
-  assign _zz_450_ = ((_zz_453_ == _zz_454_) != (1'b0));
-  assign _zz_451_ = {(_zz_455_ != (1'b0)),{(_zz_456_ != _zz_457_),{_zz_458_,{_zz_459_,_zz_460_}}}};
-  assign _zz_452_ = (32'b00000010000000000100000001100100);
-  assign _zz_453_ = (decode_INSTRUCTION & (32'b00000000000000000001000000000000));
-  assign _zz_454_ = (32'b00000000000000000001000000000000);
-  assign _zz_455_ = ((decode_INSTRUCTION & (32'b00000000000000000011000000000000)) == (32'b00000000000000000010000000000000));
-  assign _zz_456_ = {(_zz_461_ == _zz_462_),{_zz_463_,{_zz_464_,_zz_465_}}};
-  assign _zz_457_ = (5'b00000);
-  assign _zz_458_ = ({_zz_152_,{_zz_466_,_zz_467_}} != (3'b000));
-  assign _zz_459_ = ({_zz_468_,_zz_469_} != (2'b00));
-  assign _zz_460_ = {(_zz_470_ != _zz_471_),{_zz_472_,{_zz_473_,_zz_474_}}};
-  assign _zz_461_ = (decode_INSTRUCTION & (32'b00000000000000000000000001000000));
-  assign _zz_462_ = (32'b00000000000000000000000001000000);
-  assign _zz_463_ = ((decode_INSTRUCTION & (32'b00000000000000000100000000100000)) == (32'b00000000000000000100000000100000));
-  assign _zz_464_ = ((decode_INSTRUCTION & _zz_475_) == (32'b00000000000000000000000000010000));
-  assign _zz_465_ = {_zz_151_,(_zz_476_ == _zz_477_)};
-  assign _zz_466_ = _zz_156_;
-  assign _zz_467_ = ((decode_INSTRUCTION & _zz_478_) == (32'b00000000000000000000000000000100));
-  assign _zz_468_ = _zz_156_;
-  assign _zz_469_ = ((decode_INSTRUCTION & _zz_479_) == (32'b00000000000000000000000000000100));
-  assign _zz_470_ = _zz_155_;
-  assign _zz_471_ = (1'b0);
-  assign _zz_472_ = ({_zz_480_,{_zz_481_,_zz_482_}} != (5'b00000));
-  assign _zz_473_ = ({_zz_483_,_zz_484_} != (2'b00));
-  assign _zz_474_ = {(_zz_485_ != _zz_486_),{_zz_487_,{_zz_488_,_zz_489_}}};
-  assign _zz_475_ = (32'b00000000000000000000000000110000);
-  assign _zz_476_ = (decode_INSTRUCTION & (32'b00000010000000000000000000101000));
-  assign _zz_477_ = (32'b00000000000000000000000000100000);
-  assign _zz_478_ = (32'b00000000000000000010000000010100);
-  assign _zz_479_ = (32'b00000000000000000000000001001100);
-  assign _zz_480_ = ((decode_INSTRUCTION & _zz_490_) == (32'b00000000000000000000000000000000));
-  assign _zz_481_ = (_zz_491_ == _zz_492_);
-  assign _zz_482_ = {_zz_493_,{_zz_494_,_zz_495_}};
-  assign _zz_483_ = _zz_153_;
-  assign _zz_484_ = (_zz_496_ == _zz_497_);
-  assign _zz_485_ = {_zz_153_,_zz_498_};
-  assign _zz_486_ = (2'b00);
-  assign _zz_487_ = ({_zz_499_,_zz_500_} != (3'b000));
-  assign _zz_488_ = (_zz_501_ != _zz_502_);
-  assign _zz_489_ = {_zz_503_,{_zz_504_,_zz_505_}};
-  assign _zz_490_ = (32'b00000000000000000000000001000100);
-  assign _zz_491_ = (decode_INSTRUCTION & (32'b00000000000000000000000000011000));
-  assign _zz_492_ = (32'b00000000000000000000000000000000);
-  assign _zz_493_ = ((decode_INSTRUCTION & _zz_506_) == (32'b00000000000000000010000000000000));
-  assign _zz_494_ = (_zz_507_ == _zz_508_);
-  assign _zz_495_ = _zz_154_;
-  assign _zz_496_ = (decode_INSTRUCTION & (32'b00000000000000000000000001110000));
-  assign _zz_497_ = (32'b00000000000000000000000000100000);
-  assign _zz_498_ = ((decode_INSTRUCTION & _zz_509_) == (32'b00000000000000000000000000000000));
-  assign _zz_499_ = (_zz_510_ == _zz_511_);
-  assign _zz_500_ = {_zz_512_,_zz_513_};
-  assign _zz_501_ = (_zz_514_ == _zz_515_);
-  assign _zz_502_ = (1'b0);
-  assign _zz_503_ = ({_zz_516_,_zz_517_} != (7'b0000000));
-  assign _zz_504_ = (_zz_518_ != _zz_519_);
-  assign _zz_505_ = {_zz_520_,{_zz_521_,_zz_522_}};
-  assign _zz_506_ = (32'b00000000000000000110000000000100);
-  assign _zz_507_ = (decode_INSTRUCTION & (32'b00000000000000000101000000000100));
-  assign _zz_508_ = (32'b00000000000000000001000000000000);
-  assign _zz_509_ = (32'b00000000000000000000000000100000);
-  assign _zz_510_ = (decode_INSTRUCTION & (32'b00000000000000000000000001000100));
-  assign _zz_511_ = (32'b00000000000000000000000001000000);
-  assign _zz_512_ = ((decode_INSTRUCTION & (32'b00000000000000000010000000010100)) == (32'b00000000000000000010000000010000));
-  assign _zz_513_ = ((decode_INSTRUCTION & (32'b01000000000000000000000000110100)) == (32'b01000000000000000000000000110000));
-  assign _zz_514_ = (decode_INSTRUCTION & (32'b00000000000000000100000001001000));
-  assign _zz_515_ = (32'b00000000000000000100000000001000);
-  assign _zz_516_ = _zz_152_;
-  assign _zz_517_ = {(_zz_523_ == _zz_524_),{_zz_525_,{_zz_526_,_zz_527_}}};
-  assign _zz_518_ = {(_zz_528_ == _zz_529_),(_zz_530_ == _zz_531_)};
-  assign _zz_519_ = (2'b00);
-  assign _zz_520_ = ({_zz_532_,_zz_533_} != (2'b00));
-  assign _zz_521_ = ({_zz_534_,_zz_535_} != (3'b000));
-  assign _zz_522_ = {(_zz_536_ != _zz_537_),(_zz_538_ != _zz_539_)};
-  assign _zz_523_ = (decode_INSTRUCTION & (32'b00000000000000000001000000010000));
-  assign _zz_524_ = (32'b00000000000000000001000000010000);
-  assign _zz_525_ = ((decode_INSTRUCTION & _zz_540_) == (32'b00000000000000000010000000010000));
-  assign _zz_526_ = (_zz_541_ == _zz_542_);
-  assign _zz_527_ = {_zz_543_,{_zz_544_,_zz_545_}};
-  assign _zz_528_ = (decode_INSTRUCTION & (32'b00000000000000000010000000010000));
-  assign _zz_529_ = (32'b00000000000000000010000000000000);
-  assign _zz_530_ = (decode_INSTRUCTION & (32'b00000000000000000101000000000000));
-  assign _zz_531_ = (32'b00000000000000000001000000000000);
-  assign _zz_532_ = ((decode_INSTRUCTION & _zz_546_) == (32'b00000000000000000101000000010000));
-  assign _zz_533_ = ((decode_INSTRUCTION & _zz_547_) == (32'b00000000000000000101000000100000));
-  assign _zz_534_ = (_zz_548_ == _zz_549_);
-  assign _zz_535_ = {_zz_550_,_zz_551_};
-  assign _zz_536_ = (_zz_552_ == _zz_553_);
-  assign _zz_537_ = (1'b0);
-  assign _zz_538_ = {_zz_554_,{_zz_555_,_zz_556_}};
-  assign _zz_539_ = (4'b0000);
-  assign _zz_540_ = (32'b00000000000000000010000000010000);
-  assign _zz_541_ = (decode_INSTRUCTION & (32'b00000000000000000010000000001000));
-  assign _zz_542_ = (32'b00000000000000000010000000001000);
-  assign _zz_543_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001010000)) == (32'b00000000000000000000000000010000));
-  assign _zz_544_ = _zz_151_;
-  assign _zz_545_ = ((decode_INSTRUCTION & _zz_557_) == (32'b00000000000000000000000000000000));
-  assign _zz_546_ = (32'b00000000000000000111000000110100);
-  assign _zz_547_ = (32'b00000010000000000111000001100100);
-  assign _zz_548_ = (decode_INSTRUCTION & (32'b01000000000000000011000001010100));
-  assign _zz_549_ = (32'b01000000000000000001000000010000);
-  assign _zz_550_ = ((decode_INSTRUCTION & (32'b00000000000000000111000000110100)) == (32'b00000000000000000001000000010000));
-  assign _zz_551_ = ((decode_INSTRUCTION & (32'b00000010000000000111000001010100)) == (32'b00000000000000000001000000010000));
-  assign _zz_552_ = (decode_INSTRUCTION & (32'b00000000000000000101000001001000));
-  assign _zz_553_ = (32'b00000000000000000001000000001000);
-  assign _zz_554_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000110100)) == (32'b00000000000000000000000000100000));
-  assign _zz_555_ = ((decode_INSTRUCTION & _zz_558_) == (32'b00000000000000000000000000100000));
-  assign _zz_556_ = {(_zz_559_ == _zz_560_),(_zz_561_ == _zz_562_)};
-  assign _zz_557_ = (32'b00000000000000000000000000101000);
-  assign _zz_558_ = (32'b00000000000000000000000001100100);
-  assign _zz_559_ = (decode_INSTRUCTION & (32'b00001000000000000000000001110000));
-  assign _zz_560_ = (32'b00001000000000000000000000100000);
-  assign _zz_561_ = (decode_INSTRUCTION & (32'b00010000000000000000000001110000));
-  assign _zz_562_ = (32'b00000000000000000000000000100000);
-  assign _zz_563_ = (32'b00000000000000000001000001111111);
-  assign _zz_564_ = (decode_INSTRUCTION & (32'b00000000000000000010000001111111));
-  assign _zz_565_ = (32'b00000000000000000010000001110011);
-  assign _zz_566_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001111111)) == (32'b00000000000000000100000001100011));
-  assign _zz_567_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001111111)) == (32'b00000000000000000010000000010011));
-  assign _zz_568_ = {((decode_INSTRUCTION & (32'b00000000000000000110000000111111)) == (32'b00000000000000000000000000100011)),{((decode_INSTRUCTION & (32'b00000000000000000010000001111111)) == (32'b00000000000000000000000000000011)),{((decode_INSTRUCTION & _zz_569_) == (32'b00000000000000000000000000000011)),{(_zz_570_ == _zz_571_),{_zz_572_,{_zz_573_,_zz_574_}}}}}};
-  assign _zz_569_ = (32'b00000000000000000101000001011111);
-  assign _zz_570_ = (decode_INSTRUCTION & (32'b00000000000000000111000001111011));
-  assign _zz_571_ = (32'b00000000000000000000000001100011);
-  assign _zz_572_ = ((decode_INSTRUCTION & (32'b00000000000000000110000001111111)) == (32'b00000000000000000000000000001111));
-  assign _zz_573_ = ((decode_INSTRUCTION & (32'b00011000000000000111000001111111)) == (32'b00000000000000000010000000101111));
-  assign _zz_574_ = {((decode_INSTRUCTION & (32'b11111100000000000000000001111111)) == (32'b00000000000000000000000000110011)),{((decode_INSTRUCTION & (32'b11101000000000000111000001111111)) == (32'b00001000000000000010000000101111)),{((decode_INSTRUCTION & _zz_575_) == (32'b00000000000000000101000000001111)),{(_zz_576_ == _zz_577_),{_zz_578_,{_zz_579_,_zz_580_}}}}}};
-  assign _zz_575_ = (32'b00000001111100000111000001111111);
-  assign _zz_576_ = (decode_INSTRUCTION & (32'b10111100000000000111000001111111));
-  assign _zz_577_ = (32'b00000000000000000101000000010011);
-  assign _zz_578_ = ((decode_INSTRUCTION & (32'b11111100000000000011000001111111)) == (32'b00000000000000000001000000010011));
-  assign _zz_579_ = ((decode_INSTRUCTION & (32'b10111110000000000111000001111111)) == (32'b00000000000000000101000000110011));
-  assign _zz_580_ = {((decode_INSTRUCTION & (32'b10111110000000000111000001111111)) == (32'b00000000000000000000000000110011)),{((decode_INSTRUCTION & (32'b11111001111100000111000001111111)) == (32'b00010000000000000010000000101111)),((decode_INSTRUCTION & (32'b11011111111111111111111111111111)) == (32'b00010000001000000000000001110011))}};
-  assign _zz_581_ = execute_INSTRUCTION[31];
-  assign _zz_582_ = execute_INSTRUCTION[31];
-  assign _zz_583_ = execute_INSTRUCTION[7];
+  assign _zz_243_ = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_244_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_245_ = 1'b1;
+  assign _zz_246_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_247_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_248_ = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_249_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_94_));
+  assign _zz_250_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_95_));
+  assign _zz_251_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_96_));
+  assign _zz_252_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! 1'b0));
+  assign _zz_253_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
+  assign _zz_254_ = (! memory_DivPlugin_div_done);
+  assign _zz_255_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_256_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_257_ = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_258_ = (IBusCachedPlugin_fetchPc_preOutput_valid && IBusCachedPlugin_fetchPc_preOutput_ready);
+  assign _zz_259_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_260_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_261_ = (1'b0 || (! 1'b1));
+  assign _zz_262_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_263_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_264_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_265_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_266_ = execute_INSTRUCTION[13 : 12];
+  assign _zz_267_ = (! memory_arbitration_isStuck);
+  assign _zz_268_ = (iBus_cmd_valid || (_zz_207_ != (3'b000)));
+  assign _zz_269_ = (_zz_238_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
+  assign _zz_270_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
+  assign _zz_271_ = ((_zz_193_ && 1'b1) && (! 1'b0));
+  assign _zz_272_ = ((_zz_194_ && 1'b1) && (! 1'b0));
+  assign _zz_273_ = ((_zz_195_ && 1'b1) && (! 1'b0));
+  assign _zz_274_ = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_275_ = execute_INSTRUCTION[13];
+  assign _zz_276_ = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_277_ = (_zz_109_ - (4'b0001));
+  assign _zz_278_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
+  assign _zz_279_ = {29'd0, _zz_278_};
+  assign _zz_280_ = _zz_125_[9:0];
+  assign _zz_281_ = (IBusCachedPlugin_iBusRsp_stages_1_input_payload >>> 12);
+  assign _zz_282_ = (IBusCachedPlugin_iBusRsp_stages_1_input_payload >>> 2);
+  assign _zz_283_ = _zz_282_[9:0];
+  assign _zz_284_ = (execute_PREDICTION_CONTEXT_line_branchWish + _zz_286_);
+  assign _zz_285_ = (execute_PREDICTION_CONTEXT_line_branchWish == (2'b10));
+  assign _zz_286_ = {1'd0, _zz_285_};
+  assign _zz_287_ = (execute_PREDICTION_CONTEXT_line_branchWish == (2'b01));
+  assign _zz_288_ = {1'd0, _zz_287_};
+  assign _zz_289_ = (execute_PREDICTION_CONTEXT_line_branchWish - _zz_291_);
+  assign _zz_290_ = execute_PREDICTION_CONTEXT_line_branchWish[1];
+  assign _zz_291_ = {1'd0, _zz_290_};
+  assign _zz_292_ = (! execute_PREDICTION_CONTEXT_line_branchWish[1]);
+  assign _zz_293_ = {1'd0, _zz_292_};
+  assign _zz_294_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
+  assign _zz_295_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
+  assign _zz_296_ = _zz_147_[0 : 0];
+  assign _zz_297_ = _zz_147_[1 : 1];
+  assign _zz_298_ = _zz_147_[4 : 4];
+  assign _zz_299_ = _zz_147_[5 : 5];
+  assign _zz_300_ = _zz_147_[6 : 6];
+  assign _zz_301_ = _zz_147_[9 : 9];
+  assign _zz_302_ = _zz_147_[10 : 10];
+  assign _zz_303_ = _zz_147_[11 : 11];
+  assign _zz_304_ = _zz_147_[12 : 12];
+  assign _zz_305_ = _zz_147_[17 : 17];
+  assign _zz_306_ = _zz_147_[18 : 18];
+  assign _zz_307_ = _zz_147_[19 : 19];
+  assign _zz_308_ = _zz_147_[21 : 21];
+  assign _zz_309_ = _zz_147_[22 : 22];
+  assign _zz_310_ = _zz_147_[23 : 23];
+  assign _zz_311_ = _zz_147_[26 : 26];
+  assign _zz_312_ = _zz_147_[27 : 27];
+  assign _zz_313_ = _zz_147_[31 : 31];
+  assign _zz_314_ = _zz_147_[32 : 32];
+  assign _zz_315_ = execute_SRC_LESS;
+  assign _zz_316_ = (3'b100);
+  assign _zz_317_ = execute_INSTRUCTION[19 : 15];
+  assign _zz_318_ = execute_INSTRUCTION[31 : 20];
+  assign _zz_319_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_320_ = ($signed(_zz_321_) + $signed(_zz_324_));
+  assign _zz_321_ = ($signed(_zz_322_) + $signed(_zz_323_));
+  assign _zz_322_ = execute_SRC1;
+  assign _zz_323_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_324_ = (execute_SRC_USE_SUB_LESS ? _zz_325_ : _zz_326_);
+  assign _zz_325_ = (32'b00000000000000000000000000000001);
+  assign _zz_326_ = (32'b00000000000000000000000000000000);
+  assign _zz_327_ = ($signed(_zz_329_) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_328_ = _zz_327_[31 : 0];
+  assign _zz_329_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_330_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_331_ = execute_INSTRUCTION[31 : 20];
+  assign _zz_332_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_333_ = (_zz_196_ & (~ _zz_334_));
+  assign _zz_334_ = (_zz_196_ - (2'b01));
+  assign _zz_335_ = ($signed(_zz_336_) + $signed(_zz_341_));
+  assign _zz_336_ = ($signed(_zz_337_) + $signed(_zz_339_));
+  assign _zz_337_ = (52'b0000000000000000000000000000000000000000000000000000);
+  assign _zz_338_ = {1'b0,memory_MUL_LL};
+  assign _zz_339_ = {{19{_zz_338_[32]}}, _zz_338_};
+  assign _zz_340_ = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_341_ = {{2{_zz_340_[49]}}, _zz_340_};
+  assign _zz_342_ = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_343_ = {{2{_zz_342_[49]}}, _zz_342_};
+  assign _zz_344_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_345_ = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_346_ = writeBack_MUL_LOW[31 : 0];
+  assign _zz_347_ = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_348_ = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_349_ = {5'd0, _zz_348_};
+  assign _zz_350_ = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_351_ = {_zz_198_,(! _zz_200_[32])};
+  assign _zz_352_ = _zz_200_[31:0];
+  assign _zz_353_ = _zz_199_[31:0];
+  assign _zz_354_ = _zz_355_;
+  assign _zz_355_ = _zz_356_;
+  assign _zz_356_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_201_) : _zz_201_)} + _zz_358_);
+  assign _zz_357_ = memory_DivPlugin_div_needRevert;
+  assign _zz_358_ = {32'd0, _zz_357_};
+  assign _zz_359_ = _zz_203_;
+  assign _zz_360_ = {32'd0, _zz_359_};
+  assign _zz_361_ = _zz_202_;
+  assign _zz_362_ = {31'd0, _zz_361_};
+  assign _zz_363_ = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_364_ = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_365_ = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_366_ = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_367_ = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_368_ = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_369_ = (iBus_cmd_payload_address >>> 5);
+  assign _zz_370_ = {IBusCachedPlugin_predictor_historyWrite_payload_data_target,{IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish,IBusCachedPlugin_predictor_historyWrite_payload_data_source}};
+  assign _zz_371_ = 1'b1;
+  assign _zz_372_ = 1'b1;
+  assign _zz_373_ = {_zz_113_,_zz_112_};
+  assign _zz_374_ = (32'b00010000000000000000000000001000);
+  assign _zz_375_ = (_zz_384_ == _zz_385_);
+  assign _zz_376_ = {_zz_386_,{_zz_387_,_zz_388_}};
+  assign _zz_377_ = (_zz_389_ == _zz_390_);
+  assign _zz_378_ = {_zz_391_,{_zz_392_,_zz_393_}};
+  assign _zz_379_ = {_zz_394_,_zz_395_};
+  assign _zz_380_ = (2'b00);
+  assign _zz_381_ = ({_zz_396_,_zz_397_} != (3'b000));
+  assign _zz_382_ = (_zz_398_ != _zz_399_);
+  assign _zz_383_ = {_zz_400_,{_zz_401_,_zz_402_}};
+  assign _zz_384_ = (decode_INSTRUCTION & (32'b00000000000000000001000000010000));
+  assign _zz_385_ = (32'b00000000000000000001000000010000);
+  assign _zz_386_ = ((decode_INSTRUCTION & _zz_403_) == (32'b00000000000000000010000000010000));
+  assign _zz_387_ = (_zz_404_ == _zz_405_);
+  assign _zz_388_ = {_zz_406_,{_zz_407_,_zz_408_}};
+  assign _zz_389_ = (decode_INSTRUCTION & (32'b00000000000000000000000001010000));
+  assign _zz_390_ = (32'b00000000000000000000000001000000);
+  assign _zz_391_ = ((decode_INSTRUCTION & _zz_409_) == (32'b00000000000000000000000001000000));
+  assign _zz_392_ = (_zz_410_ == _zz_411_);
+  assign _zz_393_ = (_zz_412_ == _zz_413_);
+  assign _zz_394_ = ((decode_INSTRUCTION & _zz_414_) == (32'b00000000000000000101000000010000));
+  assign _zz_395_ = ((decode_INSTRUCTION & _zz_415_) == (32'b00000000000000000101000000100000));
+  assign _zz_396_ = (_zz_416_ == _zz_417_);
+  assign _zz_397_ = {_zz_418_,_zz_419_};
+  assign _zz_398_ = {_zz_420_,_zz_421_};
+  assign _zz_399_ = (2'b00);
+  assign _zz_400_ = (_zz_149_ != (1'b0));
+  assign _zz_401_ = (_zz_422_ != _zz_423_);
+  assign _zz_402_ = {_zz_424_,{_zz_425_,_zz_426_}};
+  assign _zz_403_ = (32'b00000000000000000010000000010000);
+  assign _zz_404_ = (decode_INSTRUCTION & (32'b00000000000000000010000000001000));
+  assign _zz_405_ = (32'b00000000000000000010000000001000);
+  assign _zz_406_ = ((decode_INSTRUCTION & _zz_427_) == (32'b00000000000000000000000000010000));
+  assign _zz_407_ = _zz_153_;
+  assign _zz_408_ = (_zz_428_ == _zz_429_);
+  assign _zz_409_ = (32'b00000000000000000011000001000000);
+  assign _zz_410_ = (decode_INSTRUCTION & (32'b00000000000000000000000000111000));
+  assign _zz_411_ = (32'b00000000000000000000000000000000);
+  assign _zz_412_ = (decode_INSTRUCTION & (32'b00011000000000000010000000001000));
+  assign _zz_413_ = (32'b00010000000000000010000000001000);
+  assign _zz_414_ = (32'b00000000000000000111000000110100);
+  assign _zz_415_ = (32'b00000010000000000111000001100100);
+  assign _zz_416_ = (decode_INSTRUCTION & (32'b01000000000000000011000001010100));
+  assign _zz_417_ = (32'b01000000000000000001000000010000);
+  assign _zz_418_ = ((decode_INSTRUCTION & _zz_430_) == (32'b00000000000000000001000000010000));
+  assign _zz_419_ = ((decode_INSTRUCTION & _zz_431_) == (32'b00000000000000000001000000010000));
+  assign _zz_420_ = ((decode_INSTRUCTION & _zz_432_) == (32'b00000000000000000010000000000000));
+  assign _zz_421_ = ((decode_INSTRUCTION & _zz_433_) == (32'b00000000000000000001000000000000));
+  assign _zz_422_ = (_zz_434_ == _zz_435_);
+  assign _zz_423_ = (1'b0);
+  assign _zz_424_ = (_zz_436_ != (1'b0));
+  assign _zz_425_ = (_zz_437_ != _zz_438_);
+  assign _zz_426_ = {_zz_439_,{_zz_440_,_zz_441_}};
+  assign _zz_427_ = (32'b00000000000000000000000001010000);
+  assign _zz_428_ = (decode_INSTRUCTION & (32'b00000000000000000000000000101000));
+  assign _zz_429_ = (32'b00000000000000000000000000000000);
+  assign _zz_430_ = (32'b00000000000000000111000000110100);
+  assign _zz_431_ = (32'b00000010000000000111000001010100);
+  assign _zz_432_ = (32'b00000000000000000010000000010000);
+  assign _zz_433_ = (32'b00000000000000000101000000000000);
+  assign _zz_434_ = (decode_INSTRUCTION & (32'b00000000000000000100000000010100));
+  assign _zz_435_ = (32'b00000000000000000100000000010000);
+  assign _zz_436_ = ((decode_INSTRUCTION & (32'b00000000000000000110000000010100)) == (32'b00000000000000000010000000010000));
+  assign _zz_437_ = ((decode_INSTRUCTION & (32'b00000010000000000100000001110100)) == (32'b00000010000000000000000000110000));
+  assign _zz_438_ = (1'b0);
+  assign _zz_439_ = ({_zz_153_,{_zz_442_,{_zz_443_,_zz_444_}}} != (5'b00000));
+  assign _zz_440_ = ({_zz_445_,{_zz_446_,_zz_447_}} != (5'b00000));
+  assign _zz_441_ = {(_zz_448_ != (1'b0)),{(_zz_449_ != _zz_450_),{_zz_451_,{_zz_452_,_zz_453_}}}};
+  assign _zz_442_ = ((decode_INSTRUCTION & _zz_454_) == (32'b00000000000000000010000000010000));
+  assign _zz_443_ = (_zz_455_ == _zz_456_);
+  assign _zz_444_ = {_zz_457_,_zz_458_};
+  assign _zz_445_ = ((decode_INSTRUCTION & _zz_459_) == (32'b00000000000000000000000001000000));
+  assign _zz_446_ = (_zz_460_ == _zz_461_);
+  assign _zz_447_ = {_zz_462_,{_zz_463_,_zz_464_}};
+  assign _zz_448_ = ((decode_INSTRUCTION & _zz_465_) == (32'b00000000000000000000000001010000));
+  assign _zz_449_ = (_zz_466_ == _zz_467_);
+  assign _zz_450_ = (1'b0);
+  assign _zz_451_ = ({_zz_468_,_zz_469_} != (3'b000));
+  assign _zz_452_ = (_zz_470_ != _zz_471_);
+  assign _zz_453_ = {_zz_472_,{_zz_473_,_zz_474_}};
+  assign _zz_454_ = (32'b00000000000000000010000000110000);
+  assign _zz_455_ = (decode_INSTRUCTION & (32'b00000000000000000001000000110000));
+  assign _zz_456_ = (32'b00000000000000000000000000010000);
+  assign _zz_457_ = ((decode_INSTRUCTION & _zz_475_) == (32'b00000000000000000000000000100000));
+  assign _zz_458_ = ((decode_INSTRUCTION & _zz_476_) == (32'b00000000000000000010000000100000));
+  assign _zz_459_ = (32'b00000000000000000000000001000000);
+  assign _zz_460_ = (decode_INSTRUCTION & (32'b00000000000000000100000000100000));
+  assign _zz_461_ = (32'b00000000000000000100000000100000);
+  assign _zz_462_ = ((decode_INSTRUCTION & _zz_477_) == (32'b00000000000000000000000000010000));
+  assign _zz_463_ = _zz_153_;
+  assign _zz_464_ = (_zz_478_ == _zz_479_);
+  assign _zz_465_ = (32'b00000000000000000011000001010000);
+  assign _zz_466_ = (decode_INSTRUCTION & (32'b00010000000000000000000000001000));
+  assign _zz_467_ = (32'b00010000000000000000000000001000);
+  assign _zz_468_ = (_zz_480_ == _zz_481_);
+  assign _zz_469_ = {_zz_482_,_zz_483_};
+  assign _zz_470_ = {_zz_484_,{_zz_485_,_zz_486_}};
+  assign _zz_471_ = (3'b000);
+  assign _zz_472_ = ({_zz_487_,_zz_488_} != (2'b00));
+  assign _zz_473_ = (_zz_489_ != _zz_490_);
+  assign _zz_474_ = {_zz_491_,{_zz_492_,_zz_493_}};
+  assign _zz_475_ = (32'b00000010000000000011000000100000);
+  assign _zz_476_ = (32'b00000010000000000010000001101000);
+  assign _zz_477_ = (32'b00000000000000000000000000110000);
+  assign _zz_478_ = (decode_INSTRUCTION & (32'b00000010000000000000000000101000));
+  assign _zz_479_ = (32'b00000000000000000000000000100000);
+  assign _zz_480_ = (decode_INSTRUCTION & (32'b00000000000000000000000001000100));
+  assign _zz_481_ = (32'b00000000000000000000000001000000);
+  assign _zz_482_ = ((decode_INSTRUCTION & _zz_494_) == (32'b00000000000000000010000000010000));
+  assign _zz_483_ = ((decode_INSTRUCTION & _zz_495_) == (32'b01000000000000000000000000110000));
+  assign _zz_484_ = ((decode_INSTRUCTION & _zz_496_) == (32'b00001000000000000000000000100000));
+  assign _zz_485_ = (_zz_497_ == _zz_498_);
+  assign _zz_486_ = (_zz_499_ == _zz_500_);
+  assign _zz_487_ = _zz_152_;
+  assign _zz_488_ = (_zz_501_ == _zz_502_);
+  assign _zz_489_ = {_zz_152_,_zz_503_};
+  assign _zz_490_ = (2'b00);
+  assign _zz_491_ = ({_zz_504_,_zz_505_} != (3'b000));
+  assign _zz_492_ = (_zz_506_ != _zz_507_);
+  assign _zz_493_ = {_zz_508_,{_zz_509_,_zz_510_}};
+  assign _zz_494_ = (32'b00000000000000000010000000010100);
+  assign _zz_495_ = (32'b01000000000000000000000000110100);
+  assign _zz_496_ = (32'b00001000000000000000000000100000);
+  assign _zz_497_ = (decode_INSTRUCTION & (32'b00010000000000000000000000100000));
+  assign _zz_498_ = (32'b00000000000000000000000000100000);
+  assign _zz_499_ = (decode_INSTRUCTION & (32'b00000000000000000000000000101000));
+  assign _zz_500_ = (32'b00000000000000000000000000100000);
+  assign _zz_501_ = (decode_INSTRUCTION & (32'b00000000000000000000000001110000));
+  assign _zz_502_ = (32'b00000000000000000000000000100000);
+  assign _zz_503_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000100000)) == (32'b00000000000000000000000000000000));
+  assign _zz_504_ = _zz_150_;
+  assign _zz_505_ = {_zz_151_,(_zz_511_ == _zz_512_)};
+  assign _zz_506_ = {_zz_151_,(_zz_513_ == _zz_514_)};
+  assign _zz_507_ = (2'b00);
+  assign _zz_508_ = ((_zz_515_ == _zz_516_) != (1'b0));
+  assign _zz_509_ = (_zz_517_ != (1'b0));
+  assign _zz_510_ = {(_zz_518_ != _zz_519_),{_zz_520_,{_zz_521_,_zz_522_}}};
+  assign _zz_511_ = (decode_INSTRUCTION & (32'b00000000000000000010000000010100));
+  assign _zz_512_ = (32'b00000000000000000000000000000100);
+  assign _zz_513_ = (decode_INSTRUCTION & (32'b00000000000000000000000001001100));
+  assign _zz_514_ = (32'b00000000000000000000000000000100);
+  assign _zz_515_ = (decode_INSTRUCTION & (32'b00000000000000000000000001100100));
+  assign _zz_516_ = (32'b00000000000000000000000000100100);
+  assign _zz_517_ = ((decode_INSTRUCTION & (32'b00000010000000000100000001100100)) == (32'b00000010000000000100000000100000));
+  assign _zz_518_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001001000)) == (32'b00000000000000000100000000001000));
+  assign _zz_519_ = (1'b0);
+  assign _zz_520_ = (((decode_INSTRUCTION & _zz_523_) == (32'b00000000000000000001000000001000)) != (1'b0));
+  assign _zz_521_ = ({_zz_150_,_zz_524_} != (2'b00));
+  assign _zz_522_ = {(_zz_525_ != (1'b0)),{(_zz_526_ != _zz_527_),{_zz_528_,{_zz_529_,_zz_530_}}}};
+  assign _zz_523_ = (32'b00000000000000000101000001001000);
+  assign _zz_524_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000011100)) == (32'b00000000000000000000000000000100));
+  assign _zz_525_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001011000)) == (32'b00000000000000000000000001000000));
+  assign _zz_526_ = {(_zz_531_ == _zz_532_),{_zz_533_,{_zz_534_,_zz_535_}}};
+  assign _zz_527_ = (5'b00000);
+  assign _zz_528_ = (_zz_149_ != (1'b0));
+  assign _zz_529_ = ({_zz_536_,_zz_537_} != (2'b00));
+  assign _zz_530_ = {(_zz_538_ != _zz_539_),{_zz_540_,{_zz_541_,_zz_542_}}};
+  assign _zz_531_ = (decode_INSTRUCTION & (32'b00000000000000000000000001000100));
+  assign _zz_532_ = (32'b00000000000000000000000000000000);
+  assign _zz_533_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000011000)) == (32'b00000000000000000000000000000000));
+  assign _zz_534_ = ((decode_INSTRUCTION & _zz_543_) == (32'b00000000000000000010000000000000));
+  assign _zz_535_ = {(_zz_544_ == _zz_545_),_zz_148_};
+  assign _zz_536_ = _zz_148_;
+  assign _zz_537_ = ((decode_INSTRUCTION & _zz_546_) == (32'b00000000000000000000000000000000));
+  assign _zz_538_ = ((decode_INSTRUCTION & _zz_547_) == (32'b00000000000000000001000000000000));
+  assign _zz_539_ = (1'b0);
+  assign _zz_540_ = ((_zz_548_ == _zz_549_) != (1'b0));
+  assign _zz_541_ = ({_zz_550_,_zz_551_} != (4'b0000));
+  assign _zz_542_ = ({_zz_552_,_zz_553_} != (2'b00));
+  assign _zz_543_ = (32'b00000000000000000110000000000100);
+  assign _zz_544_ = (decode_INSTRUCTION & (32'b00000000000000000101000000000100));
+  assign _zz_545_ = (32'b00000000000000000001000000000000);
+  assign _zz_546_ = (32'b00000000000000000000000001011000);
+  assign _zz_547_ = (32'b00000000000000000001000000000000);
+  assign _zz_548_ = (decode_INSTRUCTION & (32'b00000000000000000011000000000000));
+  assign _zz_549_ = (32'b00000000000000000010000000000000);
+  assign _zz_550_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000110100)) == (32'b00000000000000000000000000100000));
+  assign _zz_551_ = {((decode_INSTRUCTION & (32'b00000000000000000000000001100100)) == (32'b00000000000000000000000000100000)),{((decode_INSTRUCTION & (32'b00001000000000000000000001110000)) == (32'b00001000000000000000000000100000)),((decode_INSTRUCTION & (32'b00010000000000000000000001110000)) == (32'b00000000000000000000000000100000))}};
+  assign _zz_552_ = ((decode_INSTRUCTION & (32'b00000000000000000001000001010000)) == (32'b00000000000000000001000001010000));
+  assign _zz_553_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001010000)) == (32'b00000000000000000010000001010000));
+  assign _zz_554_ = (32'b00000000000000000001000001111111);
+  assign _zz_555_ = (decode_INSTRUCTION & (32'b00000000000000000010000001111111));
+  assign _zz_556_ = (32'b00000000000000000010000001110011);
+  assign _zz_557_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001111111)) == (32'b00000000000000000100000001100011));
+  assign _zz_558_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001111111)) == (32'b00000000000000000010000000010011));
+  assign _zz_559_ = {((decode_INSTRUCTION & (32'b00000000000000000110000000111111)) == (32'b00000000000000000000000000100011)),{((decode_INSTRUCTION & (32'b00000000000000000010000001111111)) == (32'b00000000000000000000000000000011)),{((decode_INSTRUCTION & _zz_560_) == (32'b00000000000000000000000000000011)),{(_zz_561_ == _zz_562_),{_zz_563_,{_zz_564_,_zz_565_}}}}}};
+  assign _zz_560_ = (32'b00000000000000000101000001011111);
+  assign _zz_561_ = (decode_INSTRUCTION & (32'b00000000000000000111000001111011));
+  assign _zz_562_ = (32'b00000000000000000000000001100011);
+  assign _zz_563_ = ((decode_INSTRUCTION & (32'b00000000000000000110000001111111)) == (32'b00000000000000000000000000001111));
+  assign _zz_564_ = ((decode_INSTRUCTION & (32'b00011000000000000111000001111111)) == (32'b00000000000000000010000000101111));
+  assign _zz_565_ = {((decode_INSTRUCTION & (32'b11111100000000000000000001111111)) == (32'b00000000000000000000000000110011)),{((decode_INSTRUCTION & (32'b11101000000000000111000001111111)) == (32'b00001000000000000010000000101111)),{((decode_INSTRUCTION & _zz_566_) == (32'b00000000000000000101000000001111)),{(_zz_567_ == _zz_568_),{_zz_569_,{_zz_570_,_zz_571_}}}}}};
+  assign _zz_566_ = (32'b00000001111100000111000001111111);
+  assign _zz_567_ = (decode_INSTRUCTION & (32'b10111100000000000111000001111111));
+  assign _zz_568_ = (32'b00000000000000000101000000010011);
+  assign _zz_569_ = ((decode_INSTRUCTION & (32'b11111100000000000011000001111111)) == (32'b00000000000000000001000000010011));
+  assign _zz_570_ = ((decode_INSTRUCTION & (32'b10111110000000000111000001111111)) == (32'b00000000000000000101000000110011));
+  assign _zz_571_ = {((decode_INSTRUCTION & (32'b10111110000000000111000001111111)) == (32'b00000000000000000000000000110011)),{((decode_INSTRUCTION & (32'b11111001111100000111000001111111)) == (32'b00010000000000000010000000101111)),((decode_INSTRUCTION & (32'b11011111111111111111111111111111)) == (32'b00010000001000000000000001110011))}};
   always @ (posedge clk) begin
-    if(_zz_61_) begin
+    if(_zz_103_) begin
+      IBusCachedPlugin_predictor_history[IBusCachedPlugin_predictor_historyWrite_payload_address] <= _zz_370_;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_126_) begin
+      _zz_239_ <= IBusCachedPlugin_predictor_history[_zz_280_];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_62_) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_379_) begin
-      _zz_248_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_371_) begin
+      _zz_240_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_380_) begin
-      _zz_249_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_372_) begin
+      _zz_241_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush(_zz_225_),
-    .io_cpu_prefetch_isValid(_zz_226_),
+    .io_flush(_zz_216_),
+    .io_cpu_prefetch_isValid(_zz_217_),
     .io_cpu_prefetch_haltIt(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt),
     .io_cpu_prefetch_pc(IBusCachedPlugin_iBusRsp_stages_0_input_payload),
-    .io_cpu_fetch_isValid(_zz_227_),
-    .io_cpu_fetch_isStuck(_zz_228_),
-    .io_cpu_fetch_isRemoved(_zz_229_),
+    .io_cpu_fetch_isValid(_zz_218_),
+    .io_cpu_fetch_isStuck(_zz_219_),
+    .io_cpu_fetch_isRemoved(_zz_220_),
     .io_cpu_fetch_pc(IBusCachedPlugin_iBusRsp_stages_1_input_payload),
     .io_cpu_fetch_data(IBusCachedPlugin_cache_io_cpu_fetch_data),
     .io_cpu_fetch_dataBypassValid(IBusCachedPlugin_s1_tightlyCoupledHit),
-    .io_cpu_fetch_dataBypass(_zz_230_),
+    .io_cpu_fetch_dataBypass(_zz_221_),
     .io_cpu_fetch_mmuBus_cmd_isValid(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid),
     .io_cpu_fetch_mmuBus_cmd_virtualAddress(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress),
     .io_cpu_fetch_mmuBus_cmd_bypassTranslation(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation),
@@ -2756,8 +2795,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuBus_busy(IBusCachedPlugin_mmuBus_busy),
     .io_cpu_fetch_physicalAddress(IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress),
     .io_cpu_fetch_haltIt(IBusCachedPlugin_cache_io_cpu_fetch_haltIt),
-    .io_cpu_decode_isValid(_zz_231_),
-    .io_cpu_decode_isStuck(_zz_232_),
+    .io_cpu_decode_isValid(_zz_222_),
+    .io_cpu_decode_isStuck(_zz_223_),
     .io_cpu_decode_pc(IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload),
     .io_cpu_decode_physicalAddress(IBusCachedPlugin_cache_io_cpu_decode_physicalAddress),
     .io_cpu_decode_data(IBusCachedPlugin_cache_io_cpu_decode_data),
@@ -2765,8 +2804,8 @@ module VexRiscv (
     .io_cpu_decode_error(IBusCachedPlugin_cache_io_cpu_decode_error),
     .io_cpu_decode_mmuRefilling(IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling),
     .io_cpu_decode_mmuException(IBusCachedPlugin_cache_io_cpu_decode_mmuException),
-    .io_cpu_decode_isUser(_zz_233_),
-    .io_cpu_fill_valid(_zz_234_),
+    .io_cpu_decode_isUser(_zz_224_),
+    .io_cpu_fill_valid(_zz_225_),
     .io_cpu_fill_payload(IBusCachedPlugin_cache_io_cpu_decode_physicalAddress),
     .io_mem_cmd_valid(IBusCachedPlugin_cache_io_mem_cmd_valid),
     .io_mem_cmd_ready(iBus_cmd_ready),
@@ -2779,25 +2818,25 @@ module VexRiscv (
     .reset(reset) 
   );
   DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid(_zz_235_),
-    .io_cpu_execute_address(_zz_236_),
+    .io_cpu_execute_isValid(_zz_226_),
+    .io_cpu_execute_address(_zz_227_),
     .io_cpu_execute_args_wr(execute_MEMORY_WR),
-    .io_cpu_execute_args_data(_zz_145_),
+    .io_cpu_execute_args_data(_zz_142_),
     .io_cpu_execute_args_size(execute_DBusCachedPlugin_size),
-    .io_cpu_execute_args_isLrsc(_zz_237_),
+    .io_cpu_execute_args_isLrsc(_zz_228_),
     .io_cpu_execute_args_isAmo(execute_MEMORY_AMO),
-    .io_cpu_execute_args_amoCtrl_swap(_zz_238_),
-    .io_cpu_execute_args_amoCtrl_alu(_zz_239_),
-    .io_cpu_memory_isValid(_zz_240_),
+    .io_cpu_execute_args_amoCtrl_swap(_zz_229_),
+    .io_cpu_execute_args_amoCtrl_alu(_zz_230_),
+    .io_cpu_memory_isValid(_zz_231_),
     .io_cpu_memory_isStuck(memory_arbitration_isStuck),
     .io_cpu_memory_isRemoved(memory_arbitration_removeIt),
     .io_cpu_memory_isWrite(dataCache_1__io_cpu_memory_isWrite),
-    .io_cpu_memory_address(_zz_241_),
+    .io_cpu_memory_address(_zz_232_),
     .io_cpu_memory_mmuBus_cmd_isValid(dataCache_1__io_cpu_memory_mmuBus_cmd_isValid),
     .io_cpu_memory_mmuBus_cmd_virtualAddress(dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress),
     .io_cpu_memory_mmuBus_cmd_bypassTranslation(dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation),
     .io_cpu_memory_mmuBus_rsp_physicalAddress(DBusCachedPlugin_mmuBus_rsp_physicalAddress),
-    .io_cpu_memory_mmuBus_rsp_isIoAccess(_zz_242_),
+    .io_cpu_memory_mmuBus_rsp_isIoAccess(_zz_233_),
     .io_cpu_memory_mmuBus_rsp_allowRead(DBusCachedPlugin_mmuBus_rsp_allowRead),
     .io_cpu_memory_mmuBus_rsp_allowWrite(DBusCachedPlugin_mmuBus_rsp_allowWrite),
     .io_cpu_memory_mmuBus_rsp_allowExecute(DBusCachedPlugin_mmuBus_rsp_allowExecute),
@@ -2805,22 +2844,22 @@ module VexRiscv (
     .io_cpu_memory_mmuBus_rsp_refilling(DBusCachedPlugin_mmuBus_rsp_refilling),
     .io_cpu_memory_mmuBus_end(dataCache_1__io_cpu_memory_mmuBus_end),
     .io_cpu_memory_mmuBus_busy(DBusCachedPlugin_mmuBus_busy),
-    .io_cpu_writeBack_isValid(_zz_243_),
+    .io_cpu_writeBack_isValid(_zz_234_),
     .io_cpu_writeBack_isStuck(writeBack_arbitration_isStuck),
-    .io_cpu_writeBack_isUser(_zz_244_),
+    .io_cpu_writeBack_isUser(_zz_235_),
     .io_cpu_writeBack_haltIt(dataCache_1__io_cpu_writeBack_haltIt),
     .io_cpu_writeBack_isWrite(dataCache_1__io_cpu_writeBack_isWrite),
     .io_cpu_writeBack_data(dataCache_1__io_cpu_writeBack_data),
-    .io_cpu_writeBack_address(_zz_245_),
+    .io_cpu_writeBack_address(_zz_236_),
     .io_cpu_writeBack_mmuException(dataCache_1__io_cpu_writeBack_mmuException),
     .io_cpu_writeBack_unalignedAccess(dataCache_1__io_cpu_writeBack_unalignedAccess),
     .io_cpu_writeBack_accessError(dataCache_1__io_cpu_writeBack_accessError),
     .io_cpu_writeBack_clearLrsc(contextSwitching),
     .io_cpu_redo(dataCache_1__io_cpu_redo),
-    .io_cpu_flush_valid(_zz_246_),
+    .io_cpu_flush_valid(_zz_237_),
     .io_cpu_flush_ready(dataCache_1__io_cpu_flush_ready),
     .io_mem_cmd_valid(dataCache_1__io_mem_cmd_valid),
-    .io_mem_cmd_ready(_zz_247_),
+    .io_mem_cmd_ready(_zz_238_),
     .io_mem_cmd_payload_wr(dataCache_1__io_mem_cmd_payload_wr),
     .io_mem_cmd_payload_address(dataCache_1__io_mem_cmd_payload_address),
     .io_mem_cmd_payload_data(dataCache_1__io_mem_cmd_payload_data),
@@ -2834,21 +2873,18 @@ module VexRiscv (
     .reset(reset) 
   );
   always @(*) begin
-    case(_zz_381_)
-      3'b000 : begin
-        _zz_250_ = DBusCachedPlugin_redoBranch_payload;
+    case(_zz_373_)
+      2'b00 : begin
+        _zz_242_ = DBusCachedPlugin_redoBranch_payload;
       end
-      3'b001 : begin
-        _zz_250_ = CsrPlugin_jumpInterface_payload;
+      2'b01 : begin
+        _zz_242_ = CsrPlugin_jumpInterface_payload;
       end
-      3'b010 : begin
-        _zz_250_ = BranchPlugin_jumpInterface_payload;
-      end
-      3'b011 : begin
-        _zz_250_ = IBusCachedPlugin_redoBranch_payload;
+      2'b10 : begin
+        _zz_242_ = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_250_ = IBusCachedPlugin_pcs_4;
+        _zz_242_ = IBusCachedPlugin_redoBranch_payload;
       end
     endcase
   end
@@ -2887,57 +2923,39 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_4_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_4__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_4__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_4__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_4__string = "SRA_1    ";
-      default : _zz_4__string = "?????????";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_4__string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_4__string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_4__string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_4__string = "URS1        ";
+      default : _zz_4__string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_5_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_5__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_5__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_5__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_5__string = "SRA_1    ";
-      default : _zz_5__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_5__string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_5__string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_5__string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_5__string = "URS1        ";
+      default : _zz_5__string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_6_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_6__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_6__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_6__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_6__string = "SRA_1    ";
-      default : _zz_6__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_7__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_7__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_7__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_7__string = "SRA_1    ";
-      default : _zz_7__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_8__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_8__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_8__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_8__string = "SRA_1    ";
-      default : _zz_8__string = "?????????";
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_6__string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_6__string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_6__string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_6__string = "URS1        ";
+      default : _zz_6__string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2947,6 +2965,24 @@ module VexRiscv (
       `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
       `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_7_)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_7__string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_7__string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_7__string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_7__string = "PC ";
+      default : _zz_7__string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8_)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_8__string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_8__string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_8__string = "PC ";
+      default : _zz_8__string = "???";
     endcase
   end
   always @(*) begin
@@ -2960,102 +2996,30 @@ module VexRiscv (
   end
   always @(*) begin
     case(_zz_10_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_10__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_10__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_10__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_10__string = "PC ";
-      default : _zz_10__string = "???";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET";
+      default : _zz_10__string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_11_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_11__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_11__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_11__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_11__string = "PC ";
-      default : _zz_11__string = "???";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_11__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_11__string = "XRET";
+      default : _zz_11__string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_12_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_12__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_12__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12__string = "JALR";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_12__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_12__string = "XRET";
       default : _zz_12__string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_13_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_13__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_13__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_13__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_13__string = "JALR";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_13__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_13__string = "XRET";
       default : _zz_13__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_14__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_14__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_14__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_14__string = "URS1        ";
-      default : _zz_14__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_15__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_15__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_15__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_15__string = "URS1        ";
-      default : _zz_15__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_16__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_16__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_16__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_16__string = "URS1        ";
-      default : _zz_16__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_17__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_17__string = "XRET";
-      default : _zz_17__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_18__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_18__string = "XRET";
-      default : _zz_18__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_19__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_19__string = "XRET";
-      default : _zz_19__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20__string = "XRET";
-      default : _zz_20__string = "????";
     endcase
   end
   always @(*) begin
@@ -3066,24 +3030,114 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(_zz_14_)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_14__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_14__string = "XRET";
+      default : _zz_14__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15_)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_15__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_15__string = "XRET";
+      default : _zz_15__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16_)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_16__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_16__string = "XRET";
+      default : _zz_16__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
+      default : decode_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17_)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_17__string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_17__string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_17__string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_17__string = "JALR";
+      default : _zz_17__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18_)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_18__string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_18__string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_18__string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_18__string = "JALR";
+      default : _zz_18__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19_)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_19__string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_19__string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_19__string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_19__string = "JALR";
+      default : _zz_19__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20_)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_20__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_20__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_20__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_20__string = "SRA_1    ";
+      default : _zz_20__string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_21_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_21__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_21__string = "XRET";
-      default : _zz_21__string = "????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_21__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_21__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_21__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_21__string = "SRA_1    ";
+      default : _zz_21__string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_22_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_22__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_22__string = "XRET";
-      default : _zz_22__string = "????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_22__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_22__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_22__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_22__string = "SRA_1    ";
+      default : _zz_22__string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_23_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_23__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_23__string = "XRET";
-      default : _zz_23__string = "????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_23__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_23__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_23__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_23__string = "SRA_1    ";
+      default : _zz_23__string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24_)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_24__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_24__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_24__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_24__string = "SRA_1    ";
+      default : _zz_24__string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3092,14 +3146,6 @@ module VexRiscv (
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_24_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24__string = "BITWISE ";
-      default : _zz_24__string = "????????";
     endcase
   end
   always @(*) begin
@@ -3119,24 +3165,18 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(_zz_27_)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_27__string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_27__string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_27__string = "BITWISE ";
+      default : _zz_27__string = "????????";
+    endcase
+  end
+  always @(*) begin
     case(memory_ENV_CTRL)
       `EnvCtrlEnum_defaultEncoding_NONE : memory_ENV_CTRL_string = "NONE";
       `EnvCtrlEnum_defaultEncoding_XRET : memory_ENV_CTRL_string = "XRET";
       default : memory_ENV_CTRL_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_32_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_32__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_32__string = "XRET";
-      default : _zz_32__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET";
-      default : execute_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -3147,6 +3187,20 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET";
+      default : execute_ENV_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_34_)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34__string = "XRET";
+      default : _zz_34__string = "????";
+    endcase
+  end
+  always @(*) begin
     case(writeBack_ENV_CTRL)
       `EnvCtrlEnum_defaultEncoding_NONE : writeBack_ENV_CTRL_string = "NONE";
       `EnvCtrlEnum_defaultEncoding_XRET : writeBack_ENV_CTRL_string = "XRET";
@@ -3154,10 +3208,10 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_36__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_36__string = "XRET";
-      default : _zz_36__string = "????";
+    case(_zz_37_)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_37__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_37__string = "XRET";
+      default : _zz_37__string = "????";
     endcase
   end
   always @(*) begin
@@ -3170,12 +3224,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_39__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_39__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_39__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_39__string = "JALR";
-      default : _zz_39__string = "????";
+    case(_zz_41_)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_41__string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_41__string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41__string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41__string = "JALR";
+      default : _zz_41__string = "????";
     endcase
   end
   always @(*) begin
@@ -3188,12 +3242,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_44__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_44__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_44__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_44__string = "SRA_1    ";
-      default : _zz_44__string = "?????????";
+    case(_zz_45_)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45__string = "SRA_1    ";
+      default : _zz_45__string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3206,12 +3260,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46__string = "SRA_1    ";
-      default : _zz_46__string = "?????????";
+    case(_zz_47_)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_47__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_47__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_47__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_47__string = "SRA_1    ";
+      default : _zz_47__string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3224,12 +3278,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_51__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_51__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_51__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_51__string = "PC ";
-      default : _zz_51__string = "???";
+    case(_zz_52_)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_52__string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_52__string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_52__string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_52__string = "PC ";
+      default : _zz_52__string = "???";
     endcase
   end
   always @(*) begin
@@ -3242,12 +3296,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_53_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_53__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_53__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_53__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_53__string = "URS1        ";
-      default : _zz_53__string = "????????????";
+    case(_zz_54_)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_54__string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_54__string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_54__string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_54__string = "URS1        ";
+      default : _zz_54__string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3259,11 +3313,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_56_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_56__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_56__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_56__string = "BITWISE ";
-      default : _zz_56__string = "????????";
+    case(_zz_57_)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_57__string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_57__string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_57__string = "BITWISE ";
+      default : _zz_57__string = "????????";
     endcase
   end
   always @(*) begin
@@ -3275,43 +3329,44 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_58_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_58__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_58__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_58__string = "AND_1";
-      default : _zz_58__string = "?????";
+    case(_zz_59_)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_59__string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_59__string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_59__string = "AND_1";
+      default : _zz_59__string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_68_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_68__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_68__string = "XRET";
-      default : _zz_68__string = "????";
+    case(_zz_67_)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_67__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_67__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_67__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_67__string = "SRA_1    ";
+      default : _zz_67__string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_69_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_69__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_69__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_69__string = "BITWISE ";
-      default : _zz_69__string = "????????";
+    case(_zz_70_)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_70__string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_70__string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_70__string = "BITWISE ";
+      default : _zz_70__string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_71_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_71__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_71__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_71__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_71__string = "JALR";
-      default : _zz_71__string = "????";
+    case(_zz_74_)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_74__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_74__string = "XRET";
+      default : _zz_74__string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_77_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_77__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_77__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_77__string = "AND_1";
-      default : _zz_77__string = "?????";
+    case(_zz_78_)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_78__string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_78__string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_78__string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_78__string = "PC ";
+      default : _zz_78__string = "???";
     endcase
   end
   always @(*) begin
@@ -3324,98 +3379,79 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_82_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_82__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_82__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_82__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_82__string = "PC ";
-      default : _zz_82__string = "???";
+    case(_zz_84_)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_84__string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_84__string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_84__string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_84__string = "JALR";
+      default : _zz_84__string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_87_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_87__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_87__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_87__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_87__string = "SRA_1    ";
-      default : _zz_87__string = "?????????";
+    case(_zz_88_)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_88__string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_88__string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_88__string = "AND_1";
+      default : _zz_88__string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
-      default : decode_BRANCH_CTRL_string = "????";
+    case(_zz_154_)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_154__string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_154__string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_154__string = "AND_1";
+      default : _zz_154__string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_97__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_97__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97__string = "JALR";
-      default : _zz_97__string = "????";
+    case(_zz_155_)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_155__string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_155__string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_155__string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_155__string = "JALR";
+      default : _zz_155__string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_156_)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_156__string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_156__string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_156__string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_156__string = "URS1        ";
+      default : _zz_156__string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_157_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_157__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_157__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_157__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_157__string = "SRA_1    ";
-      default : _zz_157__string = "?????????";
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_157__string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_157__string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_157__string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_157__string = "PC ";
+      default : _zz_157__string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_158_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_158__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_158__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_158__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_158__string = "PC ";
-      default : _zz_158__string = "???";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_158__string = "NONE";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_158__string = "XRET";
+      default : _zz_158__string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_159_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_159__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_159__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_159__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_159__string = "URS1        ";
-      default : _zz_159__string = "????????????";
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_159__string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_159__string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_159__string = "BITWISE ";
+      default : _zz_159__string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_160_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_160__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_160__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_160__string = "AND_1";
-      default : _zz_160__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_161_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_161__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_161__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_161__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_161__string = "JALR";
-      default : _zz_161__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_162_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_162__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_162__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_162__string = "BITWISE ";
-      default : _zz_162__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_163_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_163__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_163__string = "XRET";
-      default : _zz_163__string = "????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_160__string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_160__string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_160__string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_160__string = "SRA_1    ";
+      default : _zz_160__string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3424,6 +3460,33 @@ module VexRiscv (
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -3448,24 +3511,6 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
-    endcase
-  end
-  always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
       `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
@@ -3475,21 +3520,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3502,59 +3538,62 @@ module VexRiscv (
   end
   `endif
 
-  assign decode_MEMORY_AMO = _zz_73_;
-  assign decode_MEMORY_LRSC = _zz_72_;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_92_;
-  assign decode_ALU_BITWISE_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_67_;
-  assign _zz_4_ = _zz_5_;
-  assign decode_SHIFT_CTRL = _zz_6_;
-  assign _zz_7_ = _zz_8_;
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_70_;
-  assign decode_SRC2_CTRL = _zz_9_;
-  assign _zz_10_ = _zz_11_;
-  assign execute_MUL_LL = _zz_31_;
-  assign _zz_12_ = _zz_13_;
-  assign execute_MUL_HL = _zz_29_;
-  assign execute_SHIFT_RIGHT = _zz_45_;
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = _zz_28_;
-  assign execute_BRANCH_DO = _zz_38_;
-  assign decode_IS_DIV = _zz_76_;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_64_;
-  assign decode_CSR_READ_OPCODE = _zz_34_;
-  assign decode_MEMORY_MANAGMENT = _zz_84_;
-  assign decode_SRC1_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign memory_PC = execute_to_memory_PC;
-  assign memory_MUL_LOW = _zz_27_;
-  assign _zz_17_ = _zz_18_;
-  assign _zz_19_ = _zz_20_;
-  assign decode_ENV_CTRL = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign execute_MUL_LH = _zz_30_;
-  assign decode_CSR_WRITE_OPCODE = _zz_35_;
+  assign decode_IS_MUL = _zz_71_;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
-  assign decode_FORMAL_PC_NEXT = _zz_100_;
-  assign decode_SRC_LESS_UNSIGNED = _zz_86_;
+  assign decode_FORMAL_PC_NEXT = _zz_106_;
+  assign decode_ALU_BITWISE_CTRL = _zz_1_;
+  assign _zz_2_ = _zz_3_;
+  assign decode_SRC1_CTRL = _zz_4_;
+  assign _zz_5_ = _zz_6_;
+  assign memory_MUL_LOW = _zz_28_;
+  assign decode_MEMORY_LRSC = _zz_75_;
+  assign decode_IS_RS1_SIGNED = _zz_86_;
+  assign decode_CSR_WRITE_OPCODE = _zz_36_;
+  assign decode_SRC2_FORCE_ZERO = _zz_56_;
+  assign execute_MUL_LH = _zz_31_;
+  assign execute_MUL_LL = _zz_32_;
+  assign decode_CSR_READ_OPCODE = _zz_35_;
+  assign decode_MEMORY_AMO = _zz_65_;
+  assign execute_MUL_HL = _zz_30_;
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_78_;
-  assign execute_REGFILE_WRITE_DATA = _zz_57_;
-  assign decode_IS_CSR = _zz_66_;
-  assign execute_BRANCH_CALC = _zz_37_;
-  assign decode_IS_RS1_SIGNED = _zz_74_;
-  assign decode_PREDICTION_HAD_BRANCHED2 = _zz_41_;
-  assign decode_SRC2_FORCE_ZERO = _zz_55_;
-  assign decode_IS_RS2_SIGNED = _zz_80_;
-  assign decode_ALU_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_73_;
+  assign decode_MEMORY_MANAGMENT = _zz_82_;
+  assign decode_SRC2_CTRL = _zz_7_;
+  assign _zz_8_ = _zz_9_;
+  assign decode_IS_DIV = _zz_81_;
+  assign memory_PC = execute_to_memory_PC;
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_72_;
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_77_;
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = _zz_29_;
+  assign execute_SHIFT_RIGHT = _zz_46_;
+  assign _zz_10_ = _zz_11_;
+  assign _zz_12_ = _zz_13_;
+  assign decode_ENV_CTRL = _zz_14_;
+  assign _zz_15_ = _zz_16_;
+  assign decode_BRANCH_CTRL = _zz_17_;
+  assign _zz_18_ = _zz_19_;
+  assign decode_IS_CSR = _zz_90_;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_93_;
+  assign decode_PREDICTION_CONTEXT_hazard = _zz_98_;
+  assign decode_PREDICTION_CONTEXT_hit = _zz_99_;
+  assign decode_PREDICTION_CONTEXT_line_source = _zz_100_;
+  assign decode_PREDICTION_CONTEXT_line_branchWish = _zz_101_;
+  assign decode_PREDICTION_CONTEXT_line_target = _zz_102_;
+  assign execute_REGFILE_WRITE_DATA = _zz_58_;
+  assign decode_IS_RS2_SIGNED = _zz_69_;
+  assign _zz_20_ = _zz_21_;
+  assign decode_SHIFT_CTRL = _zz_22_;
+  assign _zz_23_ = _zz_24_;
+  assign decode_SRC_LESS_UNSIGNED = _zz_68_;
+  assign decode_ALU_CTRL = _zz_25_;
+  assign _zz_26_ = _zz_27_;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3568,22 +3607,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_32_;
-  assign execute_ENV_CTRL = _zz_33_;
-  assign writeBack_ENV_CTRL = _zz_36_;
-  assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
-  assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
+  assign memory_ENV_CTRL = _zz_33_;
+  assign execute_ENV_CTRL = _zz_34_;
+  assign writeBack_ENV_CTRL = _zz_37_;
+  assign execute_NEXT_PC2 = _zz_39_;
+  assign execute_TARGET_MISSMATCH2 = _zz_38_;
+  assign execute_BRANCH_DO = _zz_42_;
+  assign execute_BRANCH_CALC = _zz_40_;
   assign execute_PC = decode_to_execute_PC;
-  assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_40_;
-  assign execute_BRANCH_CTRL = _zz_39_;
+  assign execute_BRANCH_CTRL = _zz_41_;
   assign decode_RS2_USE = _zz_89_;
-  assign decode_RS1_USE = _zz_81_;
+  assign decode_RS1_USE = _zz_85_;
   always @ (*) begin
-    _zz_42_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_251_)begin
-      _zz_42_ = execute_CsrPlugin_readData;
+    _zz_43_ = execute_REGFILE_WRITE_DATA;
+    if(_zz_243_)begin
+      _zz_43_ = execute_CsrPlugin_readData;
     end
   end
 
@@ -3594,60 +3633,60 @@ module VexRiscv (
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    decode_RS2 = _zz_62_;
-    if(_zz_177_)begin
-      if((_zz_178_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_179_;
+    decode_RS2 = _zz_63_;
+    if(_zz_174_)begin
+      if((_zz_175_ == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_176_;
       end
     end
-    if(_zz_252_)begin
-      if(_zz_253_)begin
-        if(_zz_181_)begin
-          decode_RS2 = _zz_91_;
+    if(_zz_244_)begin
+      if(_zz_245_)begin
+        if(_zz_178_)begin
+          decode_RS2 = _zz_92_;
         end
       end
     end
-    if(_zz_254_)begin
+    if(_zz_246_)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_183_)begin
-          decode_RS2 = _zz_43_;
+        if(_zz_180_)begin
+          decode_RS2 = _zz_44_;
         end
       end
     end
-    if(_zz_255_)begin
+    if(_zz_247_)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_185_)begin
-          decode_RS2 = _zz_42_;
+        if(_zz_182_)begin
+          decode_RS2 = _zz_43_;
         end
       end
     end
   end
 
   always @ (*) begin
-    decode_RS1 = _zz_63_;
-    if(_zz_177_)begin
-      if((_zz_178_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_179_;
+    decode_RS1 = _zz_64_;
+    if(_zz_174_)begin
+      if((_zz_175_ == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_176_;
       end
     end
-    if(_zz_252_)begin
-      if(_zz_253_)begin
-        if(_zz_180_)begin
-          decode_RS1 = _zz_91_;
+    if(_zz_244_)begin
+      if(_zz_245_)begin
+        if(_zz_177_)begin
+          decode_RS1 = _zz_92_;
         end
       end
     end
-    if(_zz_254_)begin
+    if(_zz_246_)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_182_)begin
-          decode_RS1 = _zz_43_;
+        if(_zz_179_)begin
+          decode_RS1 = _zz_44_;
         end
       end
     end
-    if(_zz_255_)begin
+    if(_zz_247_)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_184_)begin
-          decode_RS1 = _zz_42_;
+        if(_zz_181_)begin
+          decode_RS1 = _zz_43_;
         end
       end
     end
@@ -3655,71 +3694,71 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_43_ = memory_REGFILE_WRITE_DATA;
+    _zz_44_ = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_43_ = _zz_173_;
+          _zz_44_ = _zz_170_;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_43_ = memory_SHIFT_RIGHT;
+          _zz_44_ = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_256_)begin
-      _zz_43_ = memory_DivPlugin_div_result;
+    if(_zz_248_)begin
+      _zz_44_ = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_44_;
-  assign execute_SHIFT_CTRL = _zz_46_;
+  assign memory_SHIFT_CTRL = _zz_45_;
+  assign execute_SHIFT_CTRL = _zz_47_;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_50_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_51_;
-  assign execute_SRC1_CTRL = _zz_53_;
-  assign decode_SRC_USE_SUB_LESS = _zz_83_;
-  assign decode_SRC_ADD_ZERO = _zz_75_;
-  assign execute_SRC_ADD_SUB = _zz_49_;
-  assign execute_SRC_LESS = _zz_47_;
-  assign execute_ALU_CTRL = _zz_56_;
-  assign execute_SRC2 = _zz_52_;
-  assign execute_SRC1 = _zz_54_;
-  assign execute_ALU_BITWISE_CTRL = _zz_58_;
-  assign _zz_59_ = writeBack_INSTRUCTION;
-  assign _zz_60_ = writeBack_REGFILE_WRITE_VALID;
+  assign _zz_51_ = execute_PC;
+  assign execute_SRC2_CTRL = _zz_52_;
+  assign execute_SRC1_CTRL = _zz_54_;
+  assign decode_SRC_USE_SUB_LESS = _zz_76_;
+  assign decode_SRC_ADD_ZERO = _zz_80_;
+  assign execute_SRC_ADD_SUB = _zz_50_;
+  assign execute_SRC_LESS = _zz_48_;
+  assign execute_ALU_CTRL = _zz_57_;
+  assign execute_SRC2 = _zz_53_;
+  assign execute_SRC1 = _zz_55_;
+  assign execute_ALU_BITWISE_CTRL = _zz_59_;
+  assign _zz_60_ = writeBack_INSTRUCTION;
+  assign _zz_61_ = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_61_ = 1'b0;
+    _zz_62_ = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_61_ = 1'b1;
+      _zz_62_ = 1'b1;
     end
   end
 
-  assign decode_INSTRUCTION_ANTICIPATED = _zz_96_;
+  assign decode_INSTRUCTION_ANTICIPATED = _zz_97_;
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_85_;
+    decode_REGFILE_WRITE_VALID = _zz_66_;
     if((decode_INSTRUCTION[11 : 7] == (5'b00000)))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = _zz_90_;
+  assign decode_LEGAL_INSTRUCTION = _zz_91_;
   assign decode_INSTRUCTION_READY = 1'b1;
   always @ (*) begin
-    _zz_91_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_92_ = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_91_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_92_ = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_284_)
+      case(_zz_276_)
         2'b00 : begin
-          _zz_91_ = _zz_355_;
+          _zz_92_ = _zz_346_;
         end
         default : begin
-          _zz_91_ = _zz_356_;
+          _zz_92_ = _zz_347_;
         end
       endcase
     end
@@ -3736,59 +3775,67 @@ module VexRiscv (
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
-  assign execute_SRC_ADD = _zz_48_;
+  assign execute_SRC_ADD = _zz_49_;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_65_;
-  assign decode_FLUSH_ALL = _zz_88_;
+  assign decode_MEMORY_ENABLE = _zz_87_;
+  assign decode_FLUSH_ALL = _zz_83_;
   always @ (*) begin
-    IBusCachedPlugin_rsp_issueDetected = _zz_93_;
-    if(_zz_257_)begin
+    IBusCachedPlugin_rsp_issueDetected = _zz_94_;
+    if(_zz_249_)begin
       IBusCachedPlugin_rsp_issueDetected = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_93_ = _zz_94_;
-    if(_zz_258_)begin
-      _zz_93_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
     _zz_94_ = _zz_95_;
-    if(_zz_259_)begin
+    if(_zz_250_)begin
       _zz_94_ = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_95_ = 1'b0;
-    if(_zz_260_)begin
+    _zz_95_ = _zz_96_;
+    if(_zz_251_)begin
       _zz_95_ = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_97_;
-  assign decode_INSTRUCTION = _zz_101_;
   always @ (*) begin
-    _zz_98_ = memory_FORMAL_PC_NEXT;
+    _zz_96_ = 1'b0;
+    if(_zz_252_)begin
+      _zz_96_ = 1'b1;
+    end
+  end
+
+  assign decode_INSTRUCTION = _zz_107_;
+  assign execute_PREDICTION_CONTEXT_hazard = decode_to_execute_PREDICTION_CONTEXT_hazard;
+  assign execute_PREDICTION_CONTEXT_hit = decode_to_execute_PREDICTION_CONTEXT_hit;
+  assign execute_PREDICTION_CONTEXT_line_source = decode_to_execute_PREDICTION_CONTEXT_line_source;
+  assign execute_PREDICTION_CONTEXT_line_branchWish = decode_to_execute_PREDICTION_CONTEXT_line_branchWish;
+  assign execute_PREDICTION_CONTEXT_line_target = decode_to_execute_PREDICTION_CONTEXT_line_target;
+  always @ (*) begin
+    _zz_103_ = 1'b0;
+    if(IBusCachedPlugin_predictor_historyWrite_valid)begin
+      _zz_103_ = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_104_ = execute_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_98_ = BranchPlugin_jumpInterface_payload;
+      _zz_104_ = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_99_ = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_99_ = IBusCachedPlugin_pcs_4;
-    end
+    _zz_105_ = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_redoBranch_valid)begin
-      _zz_99_ = IBusCachedPlugin_redoBranch_payload;
+      _zz_105_ = IBusCachedPlugin_redoBranch_payload;
     end
   end
 
-  assign decode_PC = _zz_102_;
+  assign decode_PC = _zz_108_;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @ (*) begin
@@ -3800,7 +3847,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_174_ || _zz_175_)))begin
+    if((decode_arbitration_isValid && (_zz_171_ || _zz_172_)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts))begin
@@ -3813,7 +3860,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_261_)begin
+    if(_zz_253_)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3821,16 +3868,25 @@ module VexRiscv (
     end
   end
 
-  assign decode_arbitration_flushAll = 1'b0;
+  always @ (*) begin
+    decode_arbitration_flushAll = 1'b0;
+    if(BranchPlugin_jumpInterface_valid)begin
+      decode_arbitration_flushAll = 1'b1;
+    end
+    if(BranchPlugin_branchExceptionPort_valid)begin
+      decode_arbitration_flushAll = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_246_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if((_zz_237_ && (! dataCache_1__io_cpu_flush_ready)))begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_251_)begin
+    if(_zz_243_)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3840,25 +3896,19 @@ module VexRiscv (
   assign execute_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
+    if(BranchPlugin_branchExceptionPort_valid)begin
+      execute_arbitration_removeIt = 1'b1;
+    end
     if(execute_arbitration_isFlushed)begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
-    execute_arbitration_flushAll = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
-      execute_arbitration_flushAll = 1'b1;
-    end
-    if(BranchPlugin_branchExceptionPort_valid)begin
-      execute_arbitration_flushAll = 1'b1;
-    end
-  end
-
+  assign execute_arbitration_flushAll = 1'b0;
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_256_)begin
-      if(_zz_262_)begin
+    if(_zz_248_)begin
+      if(_zz_254_)begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3867,9 +3917,6 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
-      memory_arbitration_removeIt = 1'b1;
-    end
     if(memory_arbitration_isFlushed)begin
       memory_arbitration_removeIt = 1'b1;
     end
@@ -3880,10 +3927,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       memory_arbitration_flushAll = 1'b1;
     end
-    if(_zz_263_)begin
+    if(_zz_255_)begin
       memory_arbitration_flushAll = 1'b1;
     end
-    if(_zz_264_)begin
+    if(_zz_256_)begin
       memory_arbitration_flushAll = 1'b1;
     end
   end
@@ -3922,10 +3969,10 @@ module VexRiscv (
     if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode}}} != (4'b0000)))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_263_)begin
+    if(_zz_255_)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_264_)begin
+    if(_zz_256_)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3940,21 +3987,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_263_)begin
+    if(_zz_255_)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_264_)begin
+    if(_zz_256_)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = (32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
-    if(_zz_263_)begin
+    if(_zz_255_)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
     end
-    if(_zz_264_)begin
-      case(_zz_265_)
+    if(_zz_256_)begin
+      case(_zz_257_)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3967,17 +4014,16 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,{IBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != (5'b00000));
-  assign _zz_103_ = {IBusCachedPlugin_predictionJumpInterface_valid,{IBusCachedPlugin_redoBranch_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
-  assign _zz_104_ = (_zz_103_ & (~ _zz_285_));
-  assign _zz_105_ = _zz_104_[3];
-  assign _zz_106_ = _zz_104_[4];
-  assign _zz_107_ = (_zz_104_[1] || _zz_105_);
-  assign _zz_108_ = (_zz_104_[2] || _zz_105_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_250_;
-  assign _zz_109_ = (! IBusCachedPlugin_fetcherHalt);
-  assign IBusCachedPlugin_fetchPc_output_valid = (IBusCachedPlugin_fetchPc_preOutput_valid && _zz_109_);
-  assign IBusCachedPlugin_fetchPc_preOutput_ready = (IBusCachedPlugin_fetchPc_output_ready && _zz_109_);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_redoBranch_valid}}} != (4'b0000));
+  assign _zz_109_ = {IBusCachedPlugin_redoBranch_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_110_ = (_zz_109_ & (~ _zz_277_));
+  assign _zz_111_ = _zz_110_[3];
+  assign _zz_112_ = (_zz_110_[1] || _zz_111_);
+  assign _zz_113_ = (_zz_110_[2] || _zz_111_);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_242_;
+  assign _zz_114_ = (! IBusCachedPlugin_fetcherHalt);
+  assign IBusCachedPlugin_fetchPc_output_valid = (IBusCachedPlugin_fetchPc_preOutput_valid && _zz_114_);
+  assign IBusCachedPlugin_fetchPc_preOutput_ready = (IBusCachedPlugin_fetchPc_output_ready && _zz_114_);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_preOutput_payload;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_propagatePc = 1'b0;
@@ -3987,7 +4033,10 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_287_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_279_);
+    if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid)begin
+      IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_predictionPcLoad_payload;
+    end
     if(IBusCachedPlugin_jump_pcLoad_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
@@ -4000,15 +4049,18 @@ module VexRiscv (
     if(IBusCachedPlugin_fetchPc_propagatePc)begin
       IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
     end
+    if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid)begin
+      IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
+    end
     if(IBusCachedPlugin_jump_pcLoad_valid)begin
       IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
     end
-    if(_zz_266_)begin
+    if(_zz_258_)begin
       IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_fetchPc_preOutput_valid = _zz_110_;
+  assign IBusCachedPlugin_fetchPc_preOutput_valid = _zz_115_;
   assign IBusCachedPlugin_fetchPc_preOutput_payload = IBusCachedPlugin_fetchPc_pc;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -4021,9 +4073,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_111_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_111_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_111_);
+  assign _zz_116_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_116_);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_116_);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -4032,9 +4084,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_112_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_112_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_112_);
+  assign _zz_117_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_117_);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_117_);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt = 1'b0;
@@ -4043,19 +4095,19 @@ module VexRiscv (
     end
   end
 
-  assign _zz_113_ = (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt);
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_ready && _zz_113_);
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_valid = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid && _zz_113_);
+  assign _zz_118_ = (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt);
+  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_ready && _zz_118_);
+  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_valid = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid && _zz_118_);
   assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_payload = IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload;
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_114_;
-  assign _zz_114_ = ((1'b0 && (! _zz_115_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_115_ = _zz_116_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_115_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_119_;
+  assign _zz_119_ = ((1'b0 && (! _zz_120_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_120_ = _zz_121_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_120_;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_117_)) || IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready);
-  assign _zz_117_ = _zz_118_;
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid = _zz_117_;
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload = _zz_119_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_122_)) || IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready);
+  assign _zz_122_ = _zz_123_;
+  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid = _zz_122_;
+  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload = _zz_124_;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -4069,128 +4121,67 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_decodeInput_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = (IBusCachedPlugin_iBusRsp_decodeInput_valid && (! IBusCachedPlugin_injector_decodeRemoved));
-  assign _zz_102_ = IBusCachedPlugin_iBusRsp_decodeInput_payload_pc;
-  assign _zz_101_ = IBusCachedPlugin_iBusRsp_decodeInput_payload_rsp_inst;
-  assign _zz_100_ = (decode_PC + (32'b00000000000000000000000000000100));
-  assign _zz_120_ = _zz_288_[11];
+  assign _zz_108_ = IBusCachedPlugin_iBusRsp_decodeInput_payload_pc;
+  assign _zz_107_ = IBusCachedPlugin_iBusRsp_decodeInput_payload_rsp_inst;
+  assign _zz_106_ = (decode_PC + (32'b00000000000000000000000000000100));
+  assign _zz_125_ = (IBusCachedPlugin_iBusRsp_stages_0_input_payload >>> 2);
+  assign _zz_126_ = (IBusCachedPlugin_iBusRsp_stages_0_output_ready || (IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt));
+  assign _zz_127_ = _zz_239_;
+  assign IBusCachedPlugin_predictor_line_source = _zz_127_[19 : 0];
+  assign IBusCachedPlugin_predictor_line_branchWish = _zz_127_[21 : 20];
+  assign IBusCachedPlugin_predictor_line_target = _zz_127_[53 : 22];
+  assign IBusCachedPlugin_predictor_hit = ((IBusCachedPlugin_predictor_line_source == _zz_281_) && 1'b1);
+  assign IBusCachedPlugin_predictor_hazard = (IBusCachedPlugin_predictor_historyWriteLast_valid && (IBusCachedPlugin_predictor_historyWriteLast_payload_address == _zz_283_));
+  assign IBusCachedPlugin_fetchPc_predictionPcLoad_valid = (((IBusCachedPlugin_predictor_line_branchWish[1] && IBusCachedPlugin_predictor_hit) && (! IBusCachedPlugin_predictor_hazard)) && (IBusCachedPlugin_iBusRsp_stages_1_output_valid && IBusCachedPlugin_iBusRsp_stages_1_output_ready));
+  assign IBusCachedPlugin_fetchPc_predictionPcLoad_payload = IBusCachedPlugin_predictor_line_target;
+  assign IBusCachedPlugin_predictor_fetchContext_hazard = IBusCachedPlugin_predictor_hazard;
+  assign IBusCachedPlugin_predictor_fetchContext_hit = IBusCachedPlugin_predictor_hit;
+  assign IBusCachedPlugin_predictor_fetchContext_line_source = IBusCachedPlugin_predictor_line_source;
+  assign IBusCachedPlugin_predictor_fetchContext_line_branchWish = IBusCachedPlugin_predictor_line_branchWish;
+  assign IBusCachedPlugin_predictor_fetchContext_line_target = IBusCachedPlugin_predictor_line_target;
+  assign IBusCachedPlugin_predictor_injectorContext_hazard = IBusCachedPlugin_predictor_fetchContext_regNextWhen_hazard;
+  assign IBusCachedPlugin_predictor_injectorContext_hit = IBusCachedPlugin_predictor_fetchContext_regNextWhen_hit;
+  assign IBusCachedPlugin_predictor_injectorContext_line_source = IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_source;
+  assign IBusCachedPlugin_predictor_injectorContext_line_branchWish = IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_branchWish;
+  assign IBusCachedPlugin_predictor_injectorContext_line_target = IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_target;
+  assign _zz_98_ = IBusCachedPlugin_predictor_injectorContext_hazard;
+  assign _zz_99_ = IBusCachedPlugin_predictor_injectorContext_hit;
+  assign _zz_100_ = IBusCachedPlugin_predictor_injectorContext_line_source;
+  assign _zz_101_ = IBusCachedPlugin_predictor_injectorContext_line_branchWish;
+  assign _zz_102_ = IBusCachedPlugin_predictor_injectorContext_line_target;
+  assign IBusCachedPlugin_fetchPrediction_cmd_hadBranch = ((execute_PREDICTION_CONTEXT_hit && (! execute_PREDICTION_CONTEXT_hazard)) && execute_PREDICTION_CONTEXT_line_branchWish[1]);
+  assign IBusCachedPlugin_fetchPrediction_cmd_targetPc = execute_PREDICTION_CONTEXT_line_target;
   always @ (*) begin
-    _zz_121_[18] = _zz_120_;
-    _zz_121_[17] = _zz_120_;
-    _zz_121_[16] = _zz_120_;
-    _zz_121_[15] = _zz_120_;
-    _zz_121_[14] = _zz_120_;
-    _zz_121_[13] = _zz_120_;
-    _zz_121_[12] = _zz_120_;
-    _zz_121_[11] = _zz_120_;
-    _zz_121_[10] = _zz_120_;
-    _zz_121_[9] = _zz_120_;
-    _zz_121_[8] = _zz_120_;
-    _zz_121_[7] = _zz_120_;
-    _zz_121_[6] = _zz_120_;
-    _zz_121_[5] = _zz_120_;
-    _zz_121_[4] = _zz_120_;
-    _zz_121_[3] = _zz_120_;
-    _zz_121_[2] = _zz_120_;
-    _zz_121_[1] = _zz_120_;
-    _zz_121_[0] = _zz_120_;
-  end
-
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_289_[31]));
-    if(_zz_126_)begin
-      IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
+    IBusCachedPlugin_predictor_historyWrite_valid = 1'b0;
+    if(IBusCachedPlugin_fetchPrediction_rsp_wasRight)begin
+      IBusCachedPlugin_predictor_historyWrite_valid = execute_PREDICTION_CONTEXT_hit;
+    end else begin
+      if(execute_PREDICTION_CONTEXT_hit)begin
+        IBusCachedPlugin_predictor_historyWrite_valid = 1'b1;
+      end else begin
+        IBusCachedPlugin_predictor_historyWrite_valid = 1'b1;
+      end
+    end
+    if((execute_PREDICTION_CONTEXT_hazard || (! execute_arbitration_isFiring)))begin
+      IBusCachedPlugin_predictor_historyWrite_valid = 1'b0;
     end
   end
 
-  assign _zz_122_ = _zz_290_[19];
+  assign IBusCachedPlugin_predictor_historyWrite_payload_address = IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord[11 : 2];
+  assign IBusCachedPlugin_predictor_historyWrite_payload_data_source = (IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord >>> 12);
+  assign IBusCachedPlugin_predictor_historyWrite_payload_data_target = IBusCachedPlugin_fetchPrediction_rsp_finalPc;
   always @ (*) begin
-    _zz_123_[10] = _zz_122_;
-    _zz_123_[9] = _zz_122_;
-    _zz_123_[8] = _zz_122_;
-    _zz_123_[7] = _zz_122_;
-    _zz_123_[6] = _zz_122_;
-    _zz_123_[5] = _zz_122_;
-    _zz_123_[4] = _zz_122_;
-    _zz_123_[3] = _zz_122_;
-    _zz_123_[2] = _zz_122_;
-    _zz_123_[1] = _zz_122_;
-    _zz_123_[0] = _zz_122_;
-  end
-
-  assign _zz_124_ = _zz_291_[11];
-  always @ (*) begin
-    _zz_125_[18] = _zz_124_;
-    _zz_125_[17] = _zz_124_;
-    _zz_125_[16] = _zz_124_;
-    _zz_125_[15] = _zz_124_;
-    _zz_125_[14] = _zz_124_;
-    _zz_125_[13] = _zz_124_;
-    _zz_125_[12] = _zz_124_;
-    _zz_125_[11] = _zz_124_;
-    _zz_125_[10] = _zz_124_;
-    _zz_125_[9] = _zz_124_;
-    _zz_125_[8] = _zz_124_;
-    _zz_125_[7] = _zz_124_;
-    _zz_125_[6] = _zz_124_;
-    _zz_125_[5] = _zz_124_;
-    _zz_125_[4] = _zz_124_;
-    _zz_125_[3] = _zz_124_;
-    _zz_125_[2] = _zz_124_;
-    _zz_125_[1] = _zz_124_;
-    _zz_125_[0] = _zz_124_;
-  end
-
-  always @ (*) begin
-    case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_126_ = _zz_292_[1];
+    if(IBusCachedPlugin_fetchPrediction_rsp_wasRight)begin
+      IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (_zz_284_ - _zz_288_);
+    end else begin
+      if(execute_PREDICTION_CONTEXT_hit)begin
+        IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (_zz_289_ + _zz_293_);
+      end else begin
+        IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (2'b10);
       end
-      default : begin
-        _zz_126_ = _zz_293_[1];
-      end
-    endcase
+    end
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_valid = (IBusCachedPlugin_decodePrediction_cmd_hadBranch && decode_arbitration_isFiring);
-  assign _zz_127_ = _zz_294_[19];
-  always @ (*) begin
-    _zz_128_[10] = _zz_127_;
-    _zz_128_[9] = _zz_127_;
-    _zz_128_[8] = _zz_127_;
-    _zz_128_[7] = _zz_127_;
-    _zz_128_[6] = _zz_127_;
-    _zz_128_[5] = _zz_127_;
-    _zz_128_[4] = _zz_127_;
-    _zz_128_[3] = _zz_127_;
-    _zz_128_[2] = _zz_127_;
-    _zz_128_[1] = _zz_127_;
-    _zz_128_[0] = _zz_127_;
-  end
-
-  assign _zz_129_ = _zz_295_[11];
-  always @ (*) begin
-    _zz_130_[18] = _zz_129_;
-    _zz_130_[17] = _zz_129_;
-    _zz_130_[16] = _zz_129_;
-    _zz_130_[15] = _zz_129_;
-    _zz_130_[14] = _zz_129_;
-    _zz_130_[13] = _zz_129_;
-    _zz_130_[12] = _zz_129_;
-    _zz_130_[11] = _zz_129_;
-    _zz_130_[10] = _zz_129_;
-    _zz_130_[9] = _zz_129_;
-    _zz_130_[8] = _zz_129_;
-    _zz_130_[7] = _zz_129_;
-    _zz_130_[6] = _zz_129_;
-    _zz_130_[5] = _zz_129_;
-    _zz_130_[4] = _zz_129_;
-    _zz_130_[3] = _zz_129_;
-    _zz_130_[2] = _zz_129_;
-    _zz_130_[1] = _zz_129_;
-    _zz_130_[0] = _zz_129_;
-  end
-
-  assign IBusCachedPlugin_pcs_4 = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_128_,{{{_zz_382_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_130_,{{{_zz_383_,_zz_384_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4199,22 +4190,22 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_226_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_229_ = (IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt);
-  assign _zz_230_ = (32'b00000000000000000000000000000000);
-  assign _zz_227_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_228_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_231_ = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_232_ = (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready);
-  assign _zz_233_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_96_ = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
+  assign _zz_217_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_220_ = (IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt);
+  assign _zz_221_ = (32'b00000000000000000000000000000000);
+  assign _zz_218_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_219_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_222_ = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_223_ = (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready);
+  assign _zz_224_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_97_ = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_260_)begin
+    if(_zz_252_)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_258_)begin
+    if(_zz_250_)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
     if((! IBusCachedPlugin_iBusRsp_readyForError))begin
@@ -4223,21 +4214,21 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_234_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_258_)begin
-      _zz_234_ = 1'b1;
+    _zz_225_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_250_)begin
+      _zz_225_ = 1'b1;
     end
     if((! IBusCachedPlugin_iBusRsp_readyForError))begin
-      _zz_234_ = 1'b0;
+      _zz_225_ = 1'b0;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_259_)begin
+    if(_zz_251_)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_257_)begin
+    if(_zz_249_)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
     if(IBusCachedPlugin_fetcherHalt)begin
@@ -4247,10 +4238,10 @@ module VexRiscv (
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_259_)begin
+    if(_zz_251_)begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
     end
-    if(_zz_257_)begin
+    if(_zz_249_)begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
     end
   end
@@ -4266,23 +4257,23 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
   assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
   assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_225_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || _zz_131_);
-  assign _zz_247_ = (! _zz_131_);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (_zz_131_ ? _zz_132_ : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (_zz_131_ ? _zz_133_ : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (_zz_131_ ? _zz_134_ : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (_zz_131_ ? _zz_135_ : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (_zz_131_ ? _zz_136_ : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (_zz_131_ ? _zz_137_ : dataCache_1__io_mem_cmd_payload_last);
+  assign _zz_216_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || _zz_128_);
+  assign _zz_238_ = (! _zz_128_);
+  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (_zz_128_ ? _zz_129_ : dataCache_1__io_mem_cmd_payload_wr);
+  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (_zz_128_ ? _zz_130_ : dataCache_1__io_mem_cmd_payload_address);
+  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (_zz_128_ ? _zz_131_ : dataCache_1__io_mem_cmd_payload_data);
+  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (_zz_128_ ? _zz_132_ : dataCache_1__io_mem_cmd_payload_mask);
+  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (_zz_128_ ? _zz_133_ : dataCache_1__io_mem_cmd_payload_length);
+  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (_zz_128_ ? _zz_134_ : dataCache_1__io_mem_cmd_payload_last);
   assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = _zz_138_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = _zz_139_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = _zz_140_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = _zz_141_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = _zz_142_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = _zz_143_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = _zz_144_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = _zz_135_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = _zz_136_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = _zz_137_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = _zz_138_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = _zz_139_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = _zz_140_;
+  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = _zz_141_;
   assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -4292,52 +4283,52 @@ module VexRiscv (
   assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
   assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_235_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_236_ = execute_SRC_ADD;
+  assign _zz_226_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_227_ = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_145_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_142_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_145_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_142_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_145_ = execute_RS2[31 : 0];
+        _zz_142_ = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_246_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_237_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   always @ (*) begin
-    _zz_237_ = 1'b0;
+    _zz_228_ = 1'b0;
     if(execute_MEMORY_LRSC)begin
-      _zz_237_ = 1'b1;
+      _zz_228_ = 1'b1;
     end
   end
 
-  assign _zz_239_ = execute_INSTRUCTION[31 : 29];
-  assign _zz_238_ = execute_INSTRUCTION[27];
-  assign _zz_92_ = _zz_236_[1 : 0];
-  assign _zz_240_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_241_ = memory_REGFILE_WRITE_DATA;
+  assign _zz_230_ = execute_INSTRUCTION[31 : 29];
+  assign _zz_229_ = execute_INSTRUCTION[27];
+  assign _zz_93_ = _zz_227_[1 : 0];
+  assign _zz_231_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_232_ = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
   assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
   always @ (*) begin
-    _zz_242_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    _zz_233_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
     if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_242_ = 1'b1;
+      _zz_233_ = 1'b1;
     end
   end
 
   assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_243_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_244_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_245_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_234_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_235_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_236_ = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_267_)begin
+    if(_zz_259_)begin
       if(dataCache_1__io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -4347,7 +4338,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_267_)begin
+    if(_zz_259_)begin
       if(dataCache_1__io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -4366,12 +4357,12 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_267_)begin
+    if(_zz_259_)begin
       if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_296_};
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_294_};
       end
       if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_297_};
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_295_};
       end
       if(dataCache_1__io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
@@ -4396,63 +4387,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_146_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_143_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_147_[31] = _zz_146_;
-    _zz_147_[30] = _zz_146_;
-    _zz_147_[29] = _zz_146_;
-    _zz_147_[28] = _zz_146_;
-    _zz_147_[27] = _zz_146_;
-    _zz_147_[26] = _zz_146_;
-    _zz_147_[25] = _zz_146_;
-    _zz_147_[24] = _zz_146_;
-    _zz_147_[23] = _zz_146_;
-    _zz_147_[22] = _zz_146_;
-    _zz_147_[21] = _zz_146_;
-    _zz_147_[20] = _zz_146_;
-    _zz_147_[19] = _zz_146_;
-    _zz_147_[18] = _zz_146_;
-    _zz_147_[17] = _zz_146_;
-    _zz_147_[16] = _zz_146_;
-    _zz_147_[15] = _zz_146_;
-    _zz_147_[14] = _zz_146_;
-    _zz_147_[13] = _zz_146_;
-    _zz_147_[12] = _zz_146_;
-    _zz_147_[11] = _zz_146_;
-    _zz_147_[10] = _zz_146_;
-    _zz_147_[9] = _zz_146_;
-    _zz_147_[8] = _zz_146_;
-    _zz_147_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_144_[31] = _zz_143_;
+    _zz_144_[30] = _zz_143_;
+    _zz_144_[29] = _zz_143_;
+    _zz_144_[28] = _zz_143_;
+    _zz_144_[27] = _zz_143_;
+    _zz_144_[26] = _zz_143_;
+    _zz_144_[25] = _zz_143_;
+    _zz_144_[24] = _zz_143_;
+    _zz_144_[23] = _zz_143_;
+    _zz_144_[22] = _zz_143_;
+    _zz_144_[21] = _zz_143_;
+    _zz_144_[20] = _zz_143_;
+    _zz_144_[19] = _zz_143_;
+    _zz_144_[18] = _zz_143_;
+    _zz_144_[17] = _zz_143_;
+    _zz_144_[16] = _zz_143_;
+    _zz_144_[15] = _zz_143_;
+    _zz_144_[14] = _zz_143_;
+    _zz_144_[13] = _zz_143_;
+    _zz_144_[12] = _zz_143_;
+    _zz_144_[11] = _zz_143_;
+    _zz_144_[10] = _zz_143_;
+    _zz_144_[9] = _zz_143_;
+    _zz_144_[8] = _zz_143_;
+    _zz_144_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_148_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_145_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_149_[31] = _zz_148_;
-    _zz_149_[30] = _zz_148_;
-    _zz_149_[29] = _zz_148_;
-    _zz_149_[28] = _zz_148_;
-    _zz_149_[27] = _zz_148_;
-    _zz_149_[26] = _zz_148_;
-    _zz_149_[25] = _zz_148_;
-    _zz_149_[24] = _zz_148_;
-    _zz_149_[23] = _zz_148_;
-    _zz_149_[22] = _zz_148_;
-    _zz_149_[21] = _zz_148_;
-    _zz_149_[20] = _zz_148_;
-    _zz_149_[19] = _zz_148_;
-    _zz_149_[18] = _zz_148_;
-    _zz_149_[17] = _zz_148_;
-    _zz_149_[16] = _zz_148_;
-    _zz_149_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_146_[31] = _zz_145_;
+    _zz_146_[30] = _zz_145_;
+    _zz_146_[29] = _zz_145_;
+    _zz_146_[28] = _zz_145_;
+    _zz_146_[27] = _zz_145_;
+    _zz_146_[26] = _zz_145_;
+    _zz_146_[25] = _zz_145_;
+    _zz_146_[24] = _zz_145_;
+    _zz_146_[23] = _zz_145_;
+    _zz_146_[22] = _zz_145_;
+    _zz_146_[21] = _zz_145_;
+    _zz_146_[20] = _zz_145_;
+    _zz_146_[19] = _zz_145_;
+    _zz_146_[18] = _zz_145_;
+    _zz_146_[17] = _zz_145_;
+    _zz_146_[16] = _zz_145_;
+    _zz_146_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_282_)
+    case(_zz_274_)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_147_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_144_;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_149_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_146_;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -4476,65 +4467,65 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_151_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000001100)) == (32'b00000000000000000000000000000100));
-  assign _zz_152_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001001000)) == (32'b00000000000000000000000001001000));
-  assign _zz_153_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000000100)) == (32'b00000000000000000000000000000100));
-  assign _zz_154_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001010000)) == (32'b00000000000000000010000000000000));
-  assign _zz_155_ = ((decode_INSTRUCTION & (32'b00000000000000000001000000000000)) == (32'b00000000000000000000000000000000));
-  assign _zz_156_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001010000)) == (32'b00000000000000000100000001010000));
-  assign _zz_150_ = {({_zz_151_,{_zz_385_,{_zz_386_,_zz_387_}}} != (5'b00000)),{({_zz_388_,{_zz_389_,_zz_390_}} != (4'b0000)),{({_zz_391_,_zz_392_} != (2'b00)),{(_zz_393_ != _zz_394_),{_zz_395_,{_zz_396_,_zz_397_}}}}}};
-  assign _zz_90_ = ({((decode_INSTRUCTION & (32'b00000000000000000000000001011111)) == (32'b00000000000000000000000000010111)),{((decode_INSTRUCTION & (32'b00000000000000000000000001111111)) == (32'b00000000000000000000000001101111)),{((decode_INSTRUCTION & (32'b00000000000000000001000001101111)) == (32'b00000000000000000000000000000011)),{((decode_INSTRUCTION & _zz_563_) == (32'b00000000000000000001000001110011)),{(_zz_564_ == _zz_565_),{_zz_566_,{_zz_567_,_zz_568_}}}}}}} != (22'b0000000000000000000000));
-  assign _zz_89_ = _zz_298_[0];
-  assign _zz_88_ = _zz_299_[0];
-  assign _zz_157_ = _zz_150_[3 : 2];
-  assign _zz_87_ = _zz_157_;
-  assign _zz_86_ = _zz_300_[0];
-  assign _zz_85_ = _zz_301_[0];
-  assign _zz_84_ = _zz_302_[0];
-  assign _zz_83_ = _zz_303_[0];
-  assign _zz_158_ = _zz_150_[9 : 8];
-  assign _zz_82_ = _zz_158_;
-  assign _zz_81_ = _zz_304_[0];
-  assign _zz_80_ = _zz_305_[0];
-  assign _zz_159_ = _zz_150_[13 : 12];
-  assign _zz_79_ = _zz_159_;
-  assign _zz_78_ = _zz_306_[0];
-  assign _zz_160_ = _zz_150_[16 : 15];
-  assign _zz_77_ = _zz_160_;
-  assign _zz_76_ = _zz_307_[0];
-  assign _zz_75_ = _zz_308_[0];
-  assign _zz_74_ = _zz_309_[0];
-  assign _zz_73_ = _zz_310_[0];
-  assign _zz_72_ = _zz_311_[0];
-  assign _zz_161_ = _zz_150_[23 : 22];
-  assign _zz_71_ = _zz_161_;
-  assign _zz_70_ = _zz_312_[0];
-  assign _zz_162_ = _zz_150_[26 : 25];
-  assign _zz_69_ = _zz_162_;
-  assign _zz_163_ = _zz_150_[27 : 27];
-  assign _zz_68_ = _zz_163_;
-  assign _zz_67_ = _zz_313_[0];
-  assign _zz_66_ = _zz_314_[0];
-  assign _zz_65_ = _zz_315_[0];
-  assign _zz_64_ = _zz_316_[0];
+  assign _zz_148_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001010000)) == (32'b00000000000000000010000000000000));
+  assign _zz_149_ = ((decode_INSTRUCTION & (32'b00000000000000000001000000000000)) == (32'b00000000000000000000000000000000));
+  assign _zz_150_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001001000)) == (32'b00000000000000000000000001001000));
+  assign _zz_151_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001010000)) == (32'b00000000000000000100000001010000));
+  assign _zz_152_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000000100)) == (32'b00000000000000000000000000000100));
+  assign _zz_153_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000001100)) == (32'b00000000000000000000000000000100));
+  assign _zz_147_ = {(((decode_INSTRUCTION & _zz_374_) == (32'b00000000000000000000000000001000)) != (1'b0)),{({_zz_150_,{_zz_375_,_zz_376_}} != (7'b0000000)),{({_zz_377_,_zz_378_} != (4'b0000)),{(_zz_379_ != _zz_380_),{_zz_381_,{_zz_382_,_zz_383_}}}}}};
+  assign _zz_91_ = ({((decode_INSTRUCTION & (32'b00000000000000000000000001011111)) == (32'b00000000000000000000000000010111)),{((decode_INSTRUCTION & (32'b00000000000000000000000001111111)) == (32'b00000000000000000000000001101111)),{((decode_INSTRUCTION & (32'b00000000000000000001000001101111)) == (32'b00000000000000000000000000000011)),{((decode_INSTRUCTION & _zz_554_) == (32'b00000000000000000001000001110011)),{(_zz_555_ == _zz_556_),{_zz_557_,{_zz_558_,_zz_559_}}}}}}} != (22'b0000000000000000000000));
+  assign _zz_90_ = _zz_296_[0];
+  assign _zz_89_ = _zz_297_[0];
+  assign _zz_154_ = _zz_147_[3 : 2];
+  assign _zz_88_ = _zz_154_;
+  assign _zz_87_ = _zz_298_[0];
+  assign _zz_86_ = _zz_299_[0];
+  assign _zz_85_ = _zz_300_[0];
+  assign _zz_155_ = _zz_147_[8 : 7];
+  assign _zz_84_ = _zz_155_;
+  assign _zz_83_ = _zz_301_[0];
+  assign _zz_82_ = _zz_302_[0];
+  assign _zz_81_ = _zz_303_[0];
+  assign _zz_80_ = _zz_304_[0];
+  assign _zz_156_ = _zz_147_[14 : 13];
+  assign _zz_79_ = _zz_156_;
+  assign _zz_157_ = _zz_147_[16 : 15];
+  assign _zz_78_ = _zz_157_;
+  assign _zz_77_ = _zz_305_[0];
+  assign _zz_76_ = _zz_306_[0];
+  assign _zz_75_ = _zz_307_[0];
+  assign _zz_158_ = _zz_147_[20 : 20];
+  assign _zz_74_ = _zz_158_;
+  assign _zz_73_ = _zz_308_[0];
+  assign _zz_72_ = _zz_309_[0];
+  assign _zz_71_ = _zz_310_[0];
+  assign _zz_159_ = _zz_147_[25 : 24];
+  assign _zz_70_ = _zz_159_;
+  assign _zz_69_ = _zz_311_[0];
+  assign _zz_68_ = _zz_312_[0];
+  assign _zz_160_ = _zz_147_[29 : 28];
+  assign _zz_67_ = _zz_160_;
+  assign _zz_66_ = _zz_313_[0];
+  assign _zz_65_ = _zz_314_[0];
   assign decodeExceptionPort_valid = ((decode_arbitration_isValid && decode_INSTRUCTION_READY) && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = (4'b0010);
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_248_;
-  assign decode_RegFilePlugin_rs2Data = _zz_249_;
-  assign _zz_63_ = decode_RegFilePlugin_rs1Data;
-  assign _zz_62_ = decode_RegFilePlugin_rs2Data;
+  assign decode_RegFilePlugin_rs1Data = _zz_240_;
+  assign decode_RegFilePlugin_rs2Data = _zz_241_;
+  assign _zz_64_ = decode_RegFilePlugin_rs1Data;
+  assign _zz_63_ = decode_RegFilePlugin_rs2Data;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_60_ && writeBack_arbitration_isFiring);
-    if(_zz_164_)begin
+    lastStageRegFileWrite_valid = (_zz_61_ && writeBack_arbitration_isFiring);
+    if(_zz_161_)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_59_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_91_;
+  assign lastStageRegFileWrite_payload_address = _zz_60_[11 : 7];
+  assign lastStageRegFileWrite_payload_data = _zz_92_;
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -4552,456 +4543,379 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_165_ = execute_IntAluPlugin_bitwise;
+        _zz_162_ = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_165_ = {31'd0, _zz_317_};
+        _zz_162_ = {31'd0, _zz_315_};
       end
       default : begin
-        _zz_165_ = execute_SRC_ADD_SUB;
+        _zz_162_ = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  assign _zz_57_ = _zz_165_;
-  assign _zz_55_ = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign _zz_58_ = _zz_162_;
+  assign _zz_56_ = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_166_ = execute_RS1;
+        _zz_163_ = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_166_ = {29'd0, _zz_318_};
+        _zz_163_ = {29'd0, _zz_316_};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_166_ = {execute_INSTRUCTION[31 : 12],(12'b000000000000)};
+        _zz_163_ = {execute_INSTRUCTION[31 : 12],(12'b000000000000)};
       end
       default : begin
-        _zz_166_ = {27'd0, _zz_319_};
+        _zz_163_ = {27'd0, _zz_317_};
       end
     endcase
   end
 
-  assign _zz_54_ = _zz_166_;
-  assign _zz_167_ = _zz_320_[11];
+  assign _zz_55_ = _zz_163_;
+  assign _zz_164_ = _zz_318_[11];
   always @ (*) begin
-    _zz_168_[19] = _zz_167_;
-    _zz_168_[18] = _zz_167_;
-    _zz_168_[17] = _zz_167_;
-    _zz_168_[16] = _zz_167_;
-    _zz_168_[15] = _zz_167_;
-    _zz_168_[14] = _zz_167_;
-    _zz_168_[13] = _zz_167_;
-    _zz_168_[12] = _zz_167_;
-    _zz_168_[11] = _zz_167_;
-    _zz_168_[10] = _zz_167_;
-    _zz_168_[9] = _zz_167_;
-    _zz_168_[8] = _zz_167_;
-    _zz_168_[7] = _zz_167_;
-    _zz_168_[6] = _zz_167_;
-    _zz_168_[5] = _zz_167_;
-    _zz_168_[4] = _zz_167_;
-    _zz_168_[3] = _zz_167_;
-    _zz_168_[2] = _zz_167_;
-    _zz_168_[1] = _zz_167_;
-    _zz_168_[0] = _zz_167_;
+    _zz_165_[19] = _zz_164_;
+    _zz_165_[18] = _zz_164_;
+    _zz_165_[17] = _zz_164_;
+    _zz_165_[16] = _zz_164_;
+    _zz_165_[15] = _zz_164_;
+    _zz_165_[14] = _zz_164_;
+    _zz_165_[13] = _zz_164_;
+    _zz_165_[12] = _zz_164_;
+    _zz_165_[11] = _zz_164_;
+    _zz_165_[10] = _zz_164_;
+    _zz_165_[9] = _zz_164_;
+    _zz_165_[8] = _zz_164_;
+    _zz_165_[7] = _zz_164_;
+    _zz_165_[6] = _zz_164_;
+    _zz_165_[5] = _zz_164_;
+    _zz_165_[4] = _zz_164_;
+    _zz_165_[3] = _zz_164_;
+    _zz_165_[2] = _zz_164_;
+    _zz_165_[1] = _zz_164_;
+    _zz_165_[0] = _zz_164_;
   end
 
-  assign _zz_169_ = _zz_321_[11];
+  assign _zz_166_ = _zz_319_[11];
   always @ (*) begin
-    _zz_170_[19] = _zz_169_;
-    _zz_170_[18] = _zz_169_;
-    _zz_170_[17] = _zz_169_;
-    _zz_170_[16] = _zz_169_;
-    _zz_170_[15] = _zz_169_;
-    _zz_170_[14] = _zz_169_;
-    _zz_170_[13] = _zz_169_;
-    _zz_170_[12] = _zz_169_;
-    _zz_170_[11] = _zz_169_;
-    _zz_170_[10] = _zz_169_;
-    _zz_170_[9] = _zz_169_;
-    _zz_170_[8] = _zz_169_;
-    _zz_170_[7] = _zz_169_;
-    _zz_170_[6] = _zz_169_;
-    _zz_170_[5] = _zz_169_;
-    _zz_170_[4] = _zz_169_;
-    _zz_170_[3] = _zz_169_;
-    _zz_170_[2] = _zz_169_;
-    _zz_170_[1] = _zz_169_;
-    _zz_170_[0] = _zz_169_;
+    _zz_167_[19] = _zz_166_;
+    _zz_167_[18] = _zz_166_;
+    _zz_167_[17] = _zz_166_;
+    _zz_167_[16] = _zz_166_;
+    _zz_167_[15] = _zz_166_;
+    _zz_167_[14] = _zz_166_;
+    _zz_167_[13] = _zz_166_;
+    _zz_167_[12] = _zz_166_;
+    _zz_167_[11] = _zz_166_;
+    _zz_167_[10] = _zz_166_;
+    _zz_167_[9] = _zz_166_;
+    _zz_167_[8] = _zz_166_;
+    _zz_167_[7] = _zz_166_;
+    _zz_167_[6] = _zz_166_;
+    _zz_167_[5] = _zz_166_;
+    _zz_167_[4] = _zz_166_;
+    _zz_167_[3] = _zz_166_;
+    _zz_167_[2] = _zz_166_;
+    _zz_167_[1] = _zz_166_;
+    _zz_167_[0] = _zz_166_;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_171_ = execute_RS2;
+        _zz_168_ = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_171_ = {_zz_168_,execute_INSTRUCTION[31 : 20]};
+        _zz_168_ = {_zz_165_,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_171_ = {_zz_170_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_168_ = {_zz_167_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_171_ = _zz_50_;
+        _zz_168_ = _zz_51_;
       end
     endcase
   end
 
-  assign _zz_52_ = _zz_171_;
+  assign _zz_53_ = _zz_168_;
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_322_;
+    execute_SrcPlugin_addSub = _zz_320_;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
+  assign _zz_50_ = execute_SrcPlugin_addSub;
   assign _zz_49_ = execute_SrcPlugin_addSub;
-  assign _zz_48_ = execute_SrcPlugin_addSub;
-  assign _zz_47_ = execute_SrcPlugin_less;
+  assign _zz_48_ = execute_SrcPlugin_less;
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_172_[0] = execute_SRC1[31];
-    _zz_172_[1] = execute_SRC1[30];
-    _zz_172_[2] = execute_SRC1[29];
-    _zz_172_[3] = execute_SRC1[28];
-    _zz_172_[4] = execute_SRC1[27];
-    _zz_172_[5] = execute_SRC1[26];
-    _zz_172_[6] = execute_SRC1[25];
-    _zz_172_[7] = execute_SRC1[24];
-    _zz_172_[8] = execute_SRC1[23];
-    _zz_172_[9] = execute_SRC1[22];
-    _zz_172_[10] = execute_SRC1[21];
-    _zz_172_[11] = execute_SRC1[20];
-    _zz_172_[12] = execute_SRC1[19];
-    _zz_172_[13] = execute_SRC1[18];
-    _zz_172_[14] = execute_SRC1[17];
-    _zz_172_[15] = execute_SRC1[16];
-    _zz_172_[16] = execute_SRC1[15];
-    _zz_172_[17] = execute_SRC1[14];
-    _zz_172_[18] = execute_SRC1[13];
-    _zz_172_[19] = execute_SRC1[12];
-    _zz_172_[20] = execute_SRC1[11];
-    _zz_172_[21] = execute_SRC1[10];
-    _zz_172_[22] = execute_SRC1[9];
-    _zz_172_[23] = execute_SRC1[8];
-    _zz_172_[24] = execute_SRC1[7];
-    _zz_172_[25] = execute_SRC1[6];
-    _zz_172_[26] = execute_SRC1[5];
-    _zz_172_[27] = execute_SRC1[4];
-    _zz_172_[28] = execute_SRC1[3];
-    _zz_172_[29] = execute_SRC1[2];
-    _zz_172_[30] = execute_SRC1[1];
-    _zz_172_[31] = execute_SRC1[0];
+    _zz_169_[0] = execute_SRC1[31];
+    _zz_169_[1] = execute_SRC1[30];
+    _zz_169_[2] = execute_SRC1[29];
+    _zz_169_[3] = execute_SRC1[28];
+    _zz_169_[4] = execute_SRC1[27];
+    _zz_169_[5] = execute_SRC1[26];
+    _zz_169_[6] = execute_SRC1[25];
+    _zz_169_[7] = execute_SRC1[24];
+    _zz_169_[8] = execute_SRC1[23];
+    _zz_169_[9] = execute_SRC1[22];
+    _zz_169_[10] = execute_SRC1[21];
+    _zz_169_[11] = execute_SRC1[20];
+    _zz_169_[12] = execute_SRC1[19];
+    _zz_169_[13] = execute_SRC1[18];
+    _zz_169_[14] = execute_SRC1[17];
+    _zz_169_[15] = execute_SRC1[16];
+    _zz_169_[16] = execute_SRC1[15];
+    _zz_169_[17] = execute_SRC1[14];
+    _zz_169_[18] = execute_SRC1[13];
+    _zz_169_[19] = execute_SRC1[12];
+    _zz_169_[20] = execute_SRC1[11];
+    _zz_169_[21] = execute_SRC1[10];
+    _zz_169_[22] = execute_SRC1[9];
+    _zz_169_[23] = execute_SRC1[8];
+    _zz_169_[24] = execute_SRC1[7];
+    _zz_169_[25] = execute_SRC1[6];
+    _zz_169_[26] = execute_SRC1[5];
+    _zz_169_[27] = execute_SRC1[4];
+    _zz_169_[28] = execute_SRC1[3];
+    _zz_169_[29] = execute_SRC1[2];
+    _zz_169_[30] = execute_SRC1[1];
+    _zz_169_[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_172_ : execute_SRC1);
-  assign _zz_45_ = _zz_330_;
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_169_ : execute_SRC1);
+  assign _zz_46_ = _zz_328_;
   always @ (*) begin
-    _zz_173_[0] = memory_SHIFT_RIGHT[31];
-    _zz_173_[1] = memory_SHIFT_RIGHT[30];
-    _zz_173_[2] = memory_SHIFT_RIGHT[29];
-    _zz_173_[3] = memory_SHIFT_RIGHT[28];
-    _zz_173_[4] = memory_SHIFT_RIGHT[27];
-    _zz_173_[5] = memory_SHIFT_RIGHT[26];
-    _zz_173_[6] = memory_SHIFT_RIGHT[25];
-    _zz_173_[7] = memory_SHIFT_RIGHT[24];
-    _zz_173_[8] = memory_SHIFT_RIGHT[23];
-    _zz_173_[9] = memory_SHIFT_RIGHT[22];
-    _zz_173_[10] = memory_SHIFT_RIGHT[21];
-    _zz_173_[11] = memory_SHIFT_RIGHT[20];
-    _zz_173_[12] = memory_SHIFT_RIGHT[19];
-    _zz_173_[13] = memory_SHIFT_RIGHT[18];
-    _zz_173_[14] = memory_SHIFT_RIGHT[17];
-    _zz_173_[15] = memory_SHIFT_RIGHT[16];
-    _zz_173_[16] = memory_SHIFT_RIGHT[15];
-    _zz_173_[17] = memory_SHIFT_RIGHT[14];
-    _zz_173_[18] = memory_SHIFT_RIGHT[13];
-    _zz_173_[19] = memory_SHIFT_RIGHT[12];
-    _zz_173_[20] = memory_SHIFT_RIGHT[11];
-    _zz_173_[21] = memory_SHIFT_RIGHT[10];
-    _zz_173_[22] = memory_SHIFT_RIGHT[9];
-    _zz_173_[23] = memory_SHIFT_RIGHT[8];
-    _zz_173_[24] = memory_SHIFT_RIGHT[7];
-    _zz_173_[25] = memory_SHIFT_RIGHT[6];
-    _zz_173_[26] = memory_SHIFT_RIGHT[5];
-    _zz_173_[27] = memory_SHIFT_RIGHT[4];
-    _zz_173_[28] = memory_SHIFT_RIGHT[3];
-    _zz_173_[29] = memory_SHIFT_RIGHT[2];
-    _zz_173_[30] = memory_SHIFT_RIGHT[1];
-    _zz_173_[31] = memory_SHIFT_RIGHT[0];
+    _zz_170_[0] = memory_SHIFT_RIGHT[31];
+    _zz_170_[1] = memory_SHIFT_RIGHT[30];
+    _zz_170_[2] = memory_SHIFT_RIGHT[29];
+    _zz_170_[3] = memory_SHIFT_RIGHT[28];
+    _zz_170_[4] = memory_SHIFT_RIGHT[27];
+    _zz_170_[5] = memory_SHIFT_RIGHT[26];
+    _zz_170_[6] = memory_SHIFT_RIGHT[25];
+    _zz_170_[7] = memory_SHIFT_RIGHT[24];
+    _zz_170_[8] = memory_SHIFT_RIGHT[23];
+    _zz_170_[9] = memory_SHIFT_RIGHT[22];
+    _zz_170_[10] = memory_SHIFT_RIGHT[21];
+    _zz_170_[11] = memory_SHIFT_RIGHT[20];
+    _zz_170_[12] = memory_SHIFT_RIGHT[19];
+    _zz_170_[13] = memory_SHIFT_RIGHT[18];
+    _zz_170_[14] = memory_SHIFT_RIGHT[17];
+    _zz_170_[15] = memory_SHIFT_RIGHT[16];
+    _zz_170_[16] = memory_SHIFT_RIGHT[15];
+    _zz_170_[17] = memory_SHIFT_RIGHT[14];
+    _zz_170_[18] = memory_SHIFT_RIGHT[13];
+    _zz_170_[19] = memory_SHIFT_RIGHT[12];
+    _zz_170_[20] = memory_SHIFT_RIGHT[11];
+    _zz_170_[21] = memory_SHIFT_RIGHT[10];
+    _zz_170_[22] = memory_SHIFT_RIGHT[9];
+    _zz_170_[23] = memory_SHIFT_RIGHT[8];
+    _zz_170_[24] = memory_SHIFT_RIGHT[7];
+    _zz_170_[25] = memory_SHIFT_RIGHT[6];
+    _zz_170_[26] = memory_SHIFT_RIGHT[5];
+    _zz_170_[27] = memory_SHIFT_RIGHT[4];
+    _zz_170_[28] = memory_SHIFT_RIGHT[3];
+    _zz_170_[29] = memory_SHIFT_RIGHT[2];
+    _zz_170_[30] = memory_SHIFT_RIGHT[1];
+    _zz_170_[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_174_ = 1'b0;
-    if(_zz_268_)begin
-      if(_zz_269_)begin
-        if(_zz_180_)begin
-          _zz_174_ = 1'b1;
+    _zz_171_ = 1'b0;
+    if(_zz_260_)begin
+      if(_zz_261_)begin
+        if(_zz_177_)begin
+          _zz_171_ = 1'b1;
         end
       end
     end
-    if(_zz_270_)begin
-      if(_zz_271_)begin
-        if(_zz_182_)begin
-          _zz_174_ = 1'b1;
+    if(_zz_262_)begin
+      if(_zz_263_)begin
+        if(_zz_179_)begin
+          _zz_171_ = 1'b1;
         end
       end
     end
-    if(_zz_272_)begin
-      if(_zz_273_)begin
-        if(_zz_184_)begin
-          _zz_174_ = 1'b1;
+    if(_zz_264_)begin
+      if(_zz_265_)begin
+        if(_zz_181_)begin
+          _zz_171_ = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_174_ = 1'b0;
+      _zz_171_ = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_175_ = 1'b0;
-    if(_zz_268_)begin
-      if(_zz_269_)begin
-        if(_zz_181_)begin
-          _zz_175_ = 1'b1;
+    _zz_172_ = 1'b0;
+    if(_zz_260_)begin
+      if(_zz_261_)begin
+        if(_zz_178_)begin
+          _zz_172_ = 1'b1;
         end
       end
     end
-    if(_zz_270_)begin
-      if(_zz_271_)begin
-        if(_zz_183_)begin
-          _zz_175_ = 1'b1;
+    if(_zz_262_)begin
+      if(_zz_263_)begin
+        if(_zz_180_)begin
+          _zz_172_ = 1'b1;
         end
       end
     end
-    if(_zz_272_)begin
-      if(_zz_273_)begin
-        if(_zz_185_)begin
-          _zz_175_ = 1'b1;
+    if(_zz_264_)begin
+      if(_zz_265_)begin
+        if(_zz_182_)begin
+          _zz_172_ = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_175_ = 1'b0;
+      _zz_172_ = 1'b0;
     end
   end
 
-  assign _zz_176_ = (_zz_60_ && writeBack_arbitration_isFiring);
-  assign _zz_180_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_181_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_182_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_183_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_184_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_185_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_41_ = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign _zz_173_ = (_zz_61_ && writeBack_arbitration_isFiring);
+  assign _zz_177_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_178_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_179_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_180_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_181_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_182_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_186_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_183_ = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_186_ == (3'b000))) begin
-        _zz_187_ = execute_BranchPlugin_eq;
-    end else if((_zz_186_ == (3'b001))) begin
-        _zz_187_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_186_ & (3'b101)) == (3'b101)))) begin
-        _zz_187_ = (! execute_SRC_LESS);
+    if((_zz_183_ == (3'b000))) begin
+        _zz_184_ = execute_BranchPlugin_eq;
+    end else if((_zz_183_ == (3'b001))) begin
+        _zz_184_ = (! execute_BranchPlugin_eq);
+    end else if((((_zz_183_ & (3'b101)) == (3'b101)))) begin
+        _zz_184_ = (! execute_SRC_LESS);
     end else begin
-        _zz_187_ = execute_SRC_LESS;
+        _zz_184_ = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_188_ = 1'b0;
+        _zz_185_ = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_188_ = 1'b1;
+        _zz_185_ = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_188_ = 1'b1;
+        _zz_185_ = 1'b1;
       end
       default : begin
-        _zz_188_ = _zz_187_;
+        _zz_185_ = _zz_184_;
       end
     endcase
   end
 
-  assign _zz_40_ = _zz_188_;
-  assign _zz_189_ = _zz_332_[11];
+  assign _zz_42_ = _zz_185_;
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
+  assign _zz_186_ = _zz_330_[19];
   always @ (*) begin
-    _zz_190_[19] = _zz_189_;
-    _zz_190_[18] = _zz_189_;
-    _zz_190_[17] = _zz_189_;
-    _zz_190_[16] = _zz_189_;
-    _zz_190_[15] = _zz_189_;
-    _zz_190_[14] = _zz_189_;
-    _zz_190_[13] = _zz_189_;
-    _zz_190_[12] = _zz_189_;
-    _zz_190_[11] = _zz_189_;
-    _zz_190_[10] = _zz_189_;
-    _zz_190_[9] = _zz_189_;
-    _zz_190_[8] = _zz_189_;
-    _zz_190_[7] = _zz_189_;
-    _zz_190_[6] = _zz_189_;
-    _zz_190_[5] = _zz_189_;
-    _zz_190_[4] = _zz_189_;
-    _zz_190_[3] = _zz_189_;
-    _zz_190_[2] = _zz_189_;
-    _zz_190_[1] = _zz_189_;
-    _zz_190_[0] = _zz_189_;
+    _zz_187_[10] = _zz_186_;
+    _zz_187_[9] = _zz_186_;
+    _zz_187_[8] = _zz_186_;
+    _zz_187_[7] = _zz_186_;
+    _zz_187_[6] = _zz_186_;
+    _zz_187_[5] = _zz_186_;
+    _zz_187_[4] = _zz_186_;
+    _zz_187_[3] = _zz_186_;
+    _zz_187_[2] = _zz_186_;
+    _zz_187_[1] = _zz_186_;
+    _zz_187_[0] = _zz_186_;
   end
 
-  assign _zz_191_ = _zz_333_[19];
+  assign _zz_188_ = _zz_331_[11];
   always @ (*) begin
-    _zz_192_[10] = _zz_191_;
-    _zz_192_[9] = _zz_191_;
-    _zz_192_[8] = _zz_191_;
-    _zz_192_[7] = _zz_191_;
-    _zz_192_[6] = _zz_191_;
-    _zz_192_[5] = _zz_191_;
-    _zz_192_[4] = _zz_191_;
-    _zz_192_[3] = _zz_191_;
-    _zz_192_[2] = _zz_191_;
-    _zz_192_[1] = _zz_191_;
-    _zz_192_[0] = _zz_191_;
+    _zz_189_[19] = _zz_188_;
+    _zz_189_[18] = _zz_188_;
+    _zz_189_[17] = _zz_188_;
+    _zz_189_[16] = _zz_188_;
+    _zz_189_[15] = _zz_188_;
+    _zz_189_[14] = _zz_188_;
+    _zz_189_[13] = _zz_188_;
+    _zz_189_[12] = _zz_188_;
+    _zz_189_[11] = _zz_188_;
+    _zz_189_[10] = _zz_188_;
+    _zz_189_[9] = _zz_188_;
+    _zz_189_[8] = _zz_188_;
+    _zz_189_[7] = _zz_188_;
+    _zz_189_[6] = _zz_188_;
+    _zz_189_[5] = _zz_188_;
+    _zz_189_[4] = _zz_188_;
+    _zz_189_[3] = _zz_188_;
+    _zz_189_[2] = _zz_188_;
+    _zz_189_[1] = _zz_188_;
+    _zz_189_[0] = _zz_188_;
   end
 
-  assign _zz_193_ = _zz_334_[11];
+  assign _zz_190_ = _zz_332_[11];
   always @ (*) begin
-    _zz_194_[18] = _zz_193_;
-    _zz_194_[17] = _zz_193_;
-    _zz_194_[16] = _zz_193_;
-    _zz_194_[15] = _zz_193_;
-    _zz_194_[14] = _zz_193_;
-    _zz_194_[13] = _zz_193_;
-    _zz_194_[12] = _zz_193_;
-    _zz_194_[11] = _zz_193_;
-    _zz_194_[10] = _zz_193_;
-    _zz_194_[9] = _zz_193_;
-    _zz_194_[8] = _zz_193_;
-    _zz_194_[7] = _zz_193_;
-    _zz_194_[6] = _zz_193_;
-    _zz_194_[5] = _zz_193_;
-    _zz_194_[4] = _zz_193_;
-    _zz_194_[3] = _zz_193_;
-    _zz_194_[2] = _zz_193_;
-    _zz_194_[1] = _zz_193_;
-    _zz_194_[0] = _zz_193_;
+    _zz_191_[18] = _zz_190_;
+    _zz_191_[17] = _zz_190_;
+    _zz_191_[16] = _zz_190_;
+    _zz_191_[15] = _zz_190_;
+    _zz_191_[14] = _zz_190_;
+    _zz_191_[13] = _zz_190_;
+    _zz_191_[12] = _zz_190_;
+    _zz_191_[11] = _zz_190_;
+    _zz_191_[10] = _zz_190_;
+    _zz_191_[9] = _zz_190_;
+    _zz_191_[8] = _zz_190_;
+    _zz_191_[7] = _zz_190_;
+    _zz_191_[6] = _zz_190_;
+    _zz_191_[5] = _zz_190_;
+    _zz_191_[4] = _zz_190_;
+    _zz_191_[3] = _zz_190_;
+    _zz_191_[2] = _zz_190_;
+    _zz_191_[1] = _zz_190_;
+    _zz_191_[0] = _zz_190_;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_195_ = (_zz_335_[1] ^ execute_RS1[1]);
-      end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_195_ = _zz_336_[1];
+        _zz_192_ = {{_zz_187_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
-      default : begin
-        _zz_195_ = _zz_337_[1];
-      end
-    endcase
-  end
-
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_195_);
-  assign _zz_38_ = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src1 = execute_RS1;
+        _zz_192_ = {_zz_189_,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src1 = execute_PC;
+        _zz_192_ = {{_zz_191_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign _zz_196_ = _zz_338_[11];
-  always @ (*) begin
-    _zz_197_[19] = _zz_196_;
-    _zz_197_[18] = _zz_196_;
-    _zz_197_[17] = _zz_196_;
-    _zz_197_[16] = _zz_196_;
-    _zz_197_[15] = _zz_196_;
-    _zz_197_[14] = _zz_196_;
-    _zz_197_[13] = _zz_196_;
-    _zz_197_[12] = _zz_196_;
-    _zz_197_[11] = _zz_196_;
-    _zz_197_[10] = _zz_196_;
-    _zz_197_[9] = _zz_196_;
-    _zz_197_[8] = _zz_196_;
-    _zz_197_[7] = _zz_196_;
-    _zz_197_[6] = _zz_196_;
-    _zz_197_[5] = _zz_196_;
-    _zz_197_[4] = _zz_196_;
-    _zz_197_[3] = _zz_196_;
-    _zz_197_[2] = _zz_196_;
-    _zz_197_[1] = _zz_196_;
-    _zz_197_[0] = _zz_196_;
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_197_,execute_INSTRUCTION[31 : 20]};
-      end
-      default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_199_,{{{_zz_581_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_201_,{{{_zz_582_,_zz_583_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_341_};
-        end
-      end
-    endcase
-  end
-
-  assign _zz_198_ = _zz_339_[19];
-  always @ (*) begin
-    _zz_199_[10] = _zz_198_;
-    _zz_199_[9] = _zz_198_;
-    _zz_199_[8] = _zz_198_;
-    _zz_199_[7] = _zz_198_;
-    _zz_199_[6] = _zz_198_;
-    _zz_199_[5] = _zz_198_;
-    _zz_199_[4] = _zz_198_;
-    _zz_199_[3] = _zz_198_;
-    _zz_199_[2] = _zz_198_;
-    _zz_199_[1] = _zz_198_;
-    _zz_199_[0] = _zz_198_;
-  end
-
-  assign _zz_200_ = _zz_340_[11];
-  always @ (*) begin
-    _zz_201_[18] = _zz_200_;
-    _zz_201_[17] = _zz_200_;
-    _zz_201_[16] = _zz_200_;
-    _zz_201_[15] = _zz_200_;
-    _zz_201_[14] = _zz_200_;
-    _zz_201_[13] = _zz_200_;
-    _zz_201_[12] = _zz_200_;
-    _zz_201_[11] = _zz_200_;
-    _zz_201_[10] = _zz_200_;
-    _zz_201_[9] = _zz_200_;
-    _zz_201_[8] = _zz_200_;
-    _zz_201_[7] = _zz_200_;
-    _zz_201_[6] = _zz_200_;
-    _zz_201_[5] = _zz_200_;
-    _zz_201_[4] = _zz_200_;
-    _zz_201_[3] = _zz_200_;
-    _zz_201_[2] = _zz_200_;
-    _zz_201_[1] = _zz_200_;
-    _zz_201_[0] = _zz_200_;
-  end
-
+  assign execute_BranchPlugin_branch_src2 = _zz_192_;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
-  assign _zz_37_ = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && (! memory_arbitration_isStuckByOthers)) && memory_BRANCH_DO);
-  assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
-  assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
+  assign _zz_40_ = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
+  assign _zz_39_ = (execute_PC + (32'b00000000000000000000000000000100));
+  assign _zz_38_ = (decode_PC != execute_BRANCH_CALC);
+  assign execute_BranchPlugin_predictionMissmatch = ((IBusCachedPlugin_fetchPrediction_cmd_hadBranch != execute_BRANCH_DO) || (execute_BRANCH_DO && execute_TARGET_MISSMATCH2));
+  assign IBusCachedPlugin_fetchPrediction_rsp_wasRight = (! execute_BranchPlugin_predictionMissmatch);
+  assign IBusCachedPlugin_fetchPrediction_rsp_finalPc = execute_BRANCH_CALC;
+  assign IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord = execute_PC;
+  assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && (! execute_arbitration_isStuckByOthers)) && execute_BranchPlugin_predictionMissmatch);
+  assign BranchPlugin_jumpInterface_payload = (execute_BRANCH_DO ? execute_BRANCH_CALC : execute_NEXT_PC2);
+  always @ (*) begin
+    BranchPlugin_branchExceptionPort_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && execute_BRANCH_CALC[1]);
+    if(1'b0)begin
+      BranchPlugin_branchExceptionPort_valid = 1'b0;
+    end
+  end
+
   assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
-  assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
-  assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
+  assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
   always @ (*) begin
     CsrPlugin_privilege = (2'b11);
     if(CsrPlugin_forceMachineWire)begin
@@ -5011,16 +4925,16 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = (2'b01);
   assign CsrPlugin_misa_extensions = (26'b00000000000000000001000010);
-  assign _zz_202_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_203_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_204_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_193_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_194_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_195_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_205_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_206_ = _zz_342_[0];
+  assign _zz_196_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_197_ = _zz_333_[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_261_)begin
+    if(_zz_253_)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5030,6 +4944,9 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+    if(BranchPlugin_branchExceptionPort_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
+    end
     if(execute_arbitration_isFlushed)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
@@ -5037,9 +4954,6 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
-    end
     if(memory_arbitration_isFlushed)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
@@ -5109,8 +5023,8 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign _zz_35_ = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == (5'b00000))) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == (5'b00000)))));
-  assign _zz_34_ = (decode_INSTRUCTION[13 : 7] != (7'b0100000));
+  assign _zz_36_ = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == (5'b00000))) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == (5'b00000)))));
+  assign _zz_35_ = (decode_INSTRUCTION[13 : 7] != (7'b0100000));
   assign execute_CsrPlugin_inWfi = 1'b0;
   assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
   always @ (*) begin
@@ -5180,7 +5094,7 @@ module VexRiscv (
     execute_CsrPlugin_readData = (32'b00000000000000000000000000000000);
     case(execute_CsrPlugin_csrAddress)
       12'b101111000000 : begin
-        execute_CsrPlugin_readData[31 : 0] = _zz_214_;
+        execute_CsrPlugin_readData[31 : 0] = _zz_205_;
       end
       12'b001100000000 : begin
         execute_CsrPlugin_readData[12 : 11] = CsrPlugin_mstatus_MPP;
@@ -5198,14 +5112,14 @@ module VexRiscv (
         execute_CsrPlugin_readData[3 : 3] = CsrPlugin_mip_MSIP;
       end
       12'b110011000000 : begin
-        execute_CsrPlugin_readData[12 : 0] = (13'b1000000000000);
+        execute_CsrPlugin_readData[13 : 0] = (14'b10000000000000);
         execute_CsrPlugin_readData[25 : 20] = (6'b100000);
       end
       12'b001101000011 : begin
         execute_CsrPlugin_readData[31 : 0] = CsrPlugin_mtval;
       end
       12'b111111000000 : begin
-        execute_CsrPlugin_readData[31 : 0] = _zz_215_;
+        execute_CsrPlugin_readData[31 : 0] = _zz_206_;
       end
       12'b001100000100 : begin
         execute_CsrPlugin_readData[11 : 11] = CsrPlugin_mie_MEIE;
@@ -5227,7 +5141,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = ((execute_CsrPlugin_readInstruction && (! execute_CsrPlugin_blockedBySideEffects)) && (! execute_arbitration_isStuckByOthers));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_283_)
+    case(_zz_275_)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -5241,7 +5155,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_SRC1;
   assign execute_MulPlugin_b = execute_SRC2;
   always @ (*) begin
-    case(_zz_274_)
+    case(_zz_266_)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5255,7 +5169,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_274_)
+    case(_zz_266_)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5274,16 +5188,16 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign _zz_31_ = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign _zz_30_ = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign _zz_29_ = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign _zz_28_ = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign _zz_27_ = ($signed(_zz_344_) + $signed(_zz_352_));
-  assign writeBack_MulPlugin_result = ($signed(_zz_353_) + $signed(_zz_354_));
+  assign _zz_32_ = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign _zz_31_ = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign _zz_30_ = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign _zz_29_ = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign _zz_28_ = ($signed(_zz_335_) + $signed(_zz_343_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_344_) + $signed(_zz_345_));
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_256_)begin
-      if(_zz_262_)begin
+    if(_zz_248_)begin
+      if(_zz_254_)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -5291,7 +5205,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_275_)begin
+    if(_zz_267_)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -5302,53 +5216,53 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = (6'b000000);
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_358_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_349_);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = (6'b000000);
     end
   end
 
-  assign _zz_207_ = memory_DivPlugin_rs1[31 : 0];
-  assign _zz_208_ = {memory_DivPlugin_accumulator[31 : 0],_zz_207_[31]};
-  assign _zz_209_ = (_zz_208_ - _zz_359_);
-  assign _zz_210_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_211_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_212_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_198_ = memory_DivPlugin_rs1[31 : 0];
+  assign _zz_199_ = {memory_DivPlugin_accumulator[31 : 0],_zz_198_[31]};
+  assign _zz_200_ = (_zz_199_ - _zz_350_);
+  assign _zz_201_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_202_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_203_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_213_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_213_[31 : 0] = execute_RS1;
+    _zz_204_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_204_[31 : 0] = execute_RS1;
   end
 
-  assign _zz_215_ = (_zz_214_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_215_ != (32'b00000000000000000000000000000000));
-  assign _zz_26_ = decode_ALU_CTRL;
-  assign _zz_24_ = _zz_69_;
-  assign _zz_56_ = decode_to_execute_ALU_CTRL;
-  assign _zz_23_ = decode_ENV_CTRL;
-  assign _zz_20_ = execute_ENV_CTRL;
-  assign _zz_18_ = memory_ENV_CTRL;
-  assign _zz_21_ = _zz_68_;
-  assign _zz_33_ = decode_to_execute_ENV_CTRL;
-  assign _zz_32_ = execute_to_memory_ENV_CTRL;
-  assign _zz_36_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_16_ = decode_SRC1_CTRL;
-  assign _zz_14_ = _zz_79_;
-  assign _zz_53_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_13_ = decode_BRANCH_CTRL;
-  assign _zz_97_ = _zz_71_;
-  assign _zz_39_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_11_ = decode_SRC2_CTRL;
-  assign _zz_9_ = _zz_82_;
-  assign _zz_51_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_8_ = decode_SHIFT_CTRL;
-  assign _zz_5_ = execute_SHIFT_CTRL;
-  assign _zz_6_ = _zz_87_;
-  assign _zz_46_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_44_ = execute_to_memory_SHIFT_CTRL;
+  assign _zz_206_ = (_zz_205_ & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_206_ != (32'b00000000000000000000000000000000));
+  assign _zz_27_ = decode_ALU_CTRL;
+  assign _zz_25_ = _zz_70_;
+  assign _zz_57_ = decode_to_execute_ALU_CTRL;
+  assign _zz_24_ = decode_SHIFT_CTRL;
+  assign _zz_21_ = execute_SHIFT_CTRL;
+  assign _zz_22_ = _zz_67_;
+  assign _zz_47_ = decode_to_execute_SHIFT_CTRL;
+  assign _zz_45_ = execute_to_memory_SHIFT_CTRL;
+  assign _zz_19_ = decode_BRANCH_CTRL;
+  assign _zz_17_ = _zz_84_;
+  assign _zz_41_ = decode_to_execute_BRANCH_CTRL;
+  assign _zz_16_ = decode_ENV_CTRL;
+  assign _zz_13_ = execute_ENV_CTRL;
+  assign _zz_11_ = memory_ENV_CTRL;
+  assign _zz_14_ = _zz_74_;
+  assign _zz_34_ = decode_to_execute_ENV_CTRL;
+  assign _zz_33_ = execute_to_memory_ENV_CTRL;
+  assign _zz_37_ = memory_to_writeBack_ENV_CTRL;
+  assign _zz_9_ = decode_SRC2_CTRL;
+  assign _zz_7_ = _zz_78_;
+  assign _zz_52_ = decode_to_execute_SRC2_CTRL;
+  assign _zz_6_ = decode_SRC1_CTRL;
+  assign _zz_4_ = _zz_79_;
+  assign _zz_54_ = decode_to_execute_SRC1_CTRL;
   assign _zz_3_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_1_ = _zz_77_;
-  assign _zz_58_ = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_1_ = _zz_88_;
+  assign _zz_59_ = decode_to_execute_ALU_BITWISE_CTRL;
   assign decode_arbitration_isFlushed = ({writeBack_arbitration_flushAll,{memory_arbitration_flushAll,{execute_arbitration_flushAll,decode_arbitration_flushAll}}} != (4'b0000));
   assign execute_arbitration_isFlushed = ({writeBack_arbitration_flushAll,{memory_arbitration_flushAll,execute_arbitration_flushAll}} != (3'b000));
   assign memory_arbitration_isFlushed = ({writeBack_arbitration_flushAll,memory_arbitration_flushAll} != (2'b00));
@@ -5369,64 +5283,64 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  assign iBusWishbone_ADR = {_zz_378_,_zz_216_};
-  assign iBusWishbone_CTI = ((_zz_216_ == (3'b111)) ? (3'b111) : (3'b010));
+  assign iBusWishbone_ADR = {_zz_369_,_zz_207_};
+  assign iBusWishbone_CTI = ((_zz_207_ == (3'b111)) ? (3'b111) : (3'b010));
   assign iBusWishbone_BTE = (2'b00);
   assign iBusWishbone_SEL = (4'b1111);
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = (32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_276_)begin
+    if(_zz_268_)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_276_)begin
+    if(_zz_268_)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_217_;
+  assign iBus_rsp_valid = _zz_208_;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_223_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_219_ = dBus_cmd_valid;
-  assign _zz_221_ = dBus_cmd_payload_wr;
-  assign _zz_222_ = (_zz_218_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_220_ && (_zz_221_ || _zz_222_));
-  assign dBusWishbone_ADR = ((_zz_223_ ? {{dBus_cmd_payload_address[31 : 5],_zz_218_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_223_ ? (_zz_222_ ? (3'b111) : (3'b010)) : (3'b000));
+  assign _zz_214_ = (dBus_cmd_payload_length != (3'b000));
+  assign _zz_210_ = dBus_cmd_valid;
+  assign _zz_212_ = dBus_cmd_payload_wr;
+  assign _zz_213_ = (_zz_209_ == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_211_ && (_zz_212_ || _zz_213_));
+  assign dBusWishbone_ADR = ((_zz_214_ ? {{dBus_cmd_payload_address[31 : 5],_zz_209_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_214_ ? (_zz_213_ ? (3'b111) : (3'b010)) : (3'b000));
   assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_221_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_221_;
+  assign dBusWishbone_SEL = (_zz_212_ ? dBus_cmd_payload_mask : (4'b1111));
+  assign dBusWishbone_WE = _zz_212_;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_220_ = (_zz_219_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_219_;
-  assign dBusWishbone_STB = _zz_219_;
-  assign dBus_rsp_valid = _zz_224_;
+  assign _zz_211_ = (_zz_210_ && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_210_;
+  assign dBusWishbone_STB = _zz_210_;
+  assign dBus_rsp_valid = _zz_215_;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_110_ <= 1'b0;
-      _zz_116_ <= 1'b0;
-      _zz_118_ <= 1'b0;
+      _zz_115_ <= 1'b0;
+      _zz_121_ <= 1'b0;
+      _zz_123_ <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusCachedPlugin_injector_decodeRemoved <= 1'b0;
-      _zz_131_ <= 1'b0;
-      _zz_138_ <= 1'b0;
-      _zz_164_ <= 1'b1;
-      _zz_177_ <= 1'b0;
+      _zz_128_ <= 1'b0;
+      _zz_135_ <= 1'b0;
+      _zz_161_ <= 1'b1;
+      _zz_174_ <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= (2'b11);
@@ -5441,41 +5355,44 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= (6'b000000);
-      _zz_214_ <= (32'b00000000000000000000000000000000);
+      _zz_205_ <= (32'b00000000000000000000000000000000);
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       memory_to_writeBack_REGFILE_WRITE_DATA <= (32'b00000000000000000000000000000000);
       memory_to_writeBack_INSTRUCTION <= (32'b00000000000000000000000000000000);
-      _zz_216_ <= (3'b000);
-      _zz_217_ <= 1'b0;
-      _zz_218_ <= (3'b000);
-      _zz_224_ <= 1'b0;
+      _zz_207_ <= (3'b000);
+      _zz_208_ <= 1'b0;
+      _zz_209_ <= (3'b000);
+      _zz_215_ <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_propagatePc)begin
+        IBusCachedPlugin_fetchPc_inc <= 1'b0;
+      end
+      if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid)begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_jump_pcLoad_valid)begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(_zz_266_)begin
+      if(_zz_258_)begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_samplePcNext)begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      _zz_110_ <= 1'b1;
+      _zz_115_ <= 1'b1;
       if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
-        _zz_116_ <= 1'b0;
+        _zz_121_ <= 1'b0;
       end
-      if(_zz_114_)begin
-        _zz_116_ <= IBusCachedPlugin_iBusRsp_stages_0_output_valid;
+      if(_zz_119_)begin
+        _zz_121_ <= IBusCachedPlugin_iBusRsp_stages_0_output_valid;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_118_ <= IBusCachedPlugin_iBusRsp_stages_1_output_valid;
+        _zz_123_ <= IBusCachedPlugin_iBusRsp_stages_1_output_valid;
       end
       if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
-        _zz_118_ <= 1'b0;
+        _zz_123_ <= 1'b0;
       end
       if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -5526,16 +5443,16 @@ module VexRiscv (
         IBusCachedPlugin_injector_decodeRemoved <= 1'b0;
       end
       if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        _zz_131_ <= 1'b0;
+        _zz_128_ <= 1'b0;
       end
-      if(_zz_277_)begin
-        _zz_131_ <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_269_)begin
+        _zz_128_ <= dataCache_1__io_mem_cmd_valid;
       end
       if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        _zz_138_ <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+        _zz_135_ <= dataCache_1__io_mem_cmd_s2mPipe_valid;
       end
-      _zz_164_ <= 1'b0;
-      _zz_177_ <= _zz_176_;
+      _zz_161_ <= 1'b0;
+      _zz_174_ <= _zz_173_;
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -5557,19 +5474,19 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_278_)begin
-        if(_zz_279_)begin
+      if(_zz_270_)begin
+        if(_zz_271_)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_280_)begin
+        if(_zz_272_)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_281_)begin
+        if(_zz_273_)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_263_)begin
+      if(_zz_255_)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5580,8 +5497,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_264_)begin
-        case(_zz_265_)
+      if(_zz_256_)begin
+        case(_zz_257_)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= (2'b00);
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5591,10 +5508,10 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= ({_zz_204_,{_zz_203_,_zz_202_}} != (3'b000));
+      execute_CsrPlugin_wfiWake <= ({_zz_195_,{_zz_194_,_zz_193_}} != (3'b000));
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_43_;
+        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_44_;
       end
       if((! writeBack_arbitration_isStuck))begin
         memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
@@ -5620,14 +5537,14 @@ module VexRiscv (
       case(execute_CsrPlugin_csrAddress)
         12'b101111000000 : begin
           if(execute_CsrPlugin_writeEnable)begin
-            _zz_214_ <= execute_CsrPlugin_writeData[31 : 0];
+            _zz_205_ <= execute_CsrPlugin_writeData[31 : 0];
           end
         end
         12'b001100000000 : begin
           if(execute_CsrPlugin_writeEnable)begin
             CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-            CsrPlugin_mstatus_MPIE <= _zz_372_[0];
-            CsrPlugin_mstatus_MIE <= _zz_373_[0];
+            CsrPlugin_mstatus_MPIE <= _zz_363_[0];
+            CsrPlugin_mstatus_MIE <= _zz_364_[0];
           end
         end
         12'b001101000001 : begin
@@ -5644,9 +5561,9 @@ module VexRiscv (
         end
         12'b001100000100 : begin
           if(execute_CsrPlugin_writeEnable)begin
-            CsrPlugin_mie_MEIE <= _zz_375_[0];
-            CsrPlugin_mie_MTIE <= _zz_376_[0];
-            CsrPlugin_mie_MSIE <= _zz_377_[0];
+            CsrPlugin_mie_MEIE <= _zz_366_[0];
+            CsrPlugin_mie_MTIE <= _zz_367_[0];
+            CsrPlugin_mie_MSIE <= _zz_368_[0];
           end
         end
         12'b001101000010 : begin
@@ -5654,25 +5571,39 @@ module VexRiscv (
         default : begin
         end
       endcase
-      if(_zz_276_)begin
+      if(_zz_268_)begin
         if(iBusWishbone_ACK)begin
-          _zz_216_ <= (_zz_216_ + (3'b001));
+          _zz_207_ <= (_zz_207_ + (3'b001));
         end
       end
-      _zz_217_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_219_ && _zz_220_))begin
-        _zz_218_ <= (_zz_218_ + (3'b001));
-        if(_zz_222_)begin
-          _zz_218_ <= (3'b000);
+      _zz_208_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_210_ && _zz_211_))begin
+        _zz_209_ <= (_zz_209_ + (3'b001));
+        if(_zz_213_)begin
+          _zz_209_ <= (3'b000);
         end
       end
-      _zz_224_ <= ((_zz_219_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_215_ <= ((_zz_210_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_119_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_124_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+    end
+    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready)begin
+      IBusCachedPlugin_predictor_historyWriteLast_valid <= IBusCachedPlugin_predictor_historyWrite_valid;
+      IBusCachedPlugin_predictor_historyWriteLast_payload_address <= IBusCachedPlugin_predictor_historyWrite_payload_address;
+      IBusCachedPlugin_predictor_historyWriteLast_payload_data_source <= IBusCachedPlugin_predictor_historyWrite_payload_data_source;
+      IBusCachedPlugin_predictor_historyWriteLast_payload_data_branchWish <= IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
+      IBusCachedPlugin_predictor_historyWriteLast_payload_data_target <= IBusCachedPlugin_predictor_historyWrite_payload_data_target;
+    end
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
+      IBusCachedPlugin_predictor_fetchContext_regNextWhen_hazard <= IBusCachedPlugin_predictor_fetchContext_hazard;
+      IBusCachedPlugin_predictor_fetchContext_regNextWhen_hit <= IBusCachedPlugin_predictor_fetchContext_hit;
+      IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_source <= IBusCachedPlugin_predictor_fetchContext_line_source;
+      IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_branchWish <= IBusCachedPlugin_predictor_fetchContext_line_branchWish;
+      IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_target <= IBusCachedPlugin_predictor_fetchContext_line_target;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -5680,25 +5611,25 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_277_)begin
-      _zz_132_ <= dataCache_1__io_mem_cmd_payload_wr;
-      _zz_133_ <= dataCache_1__io_mem_cmd_payload_address;
-      _zz_134_ <= dataCache_1__io_mem_cmd_payload_data;
-      _zz_135_ <= dataCache_1__io_mem_cmd_payload_mask;
-      _zz_136_ <= dataCache_1__io_mem_cmd_payload_length;
-      _zz_137_ <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_269_)begin
+      _zz_129_ <= dataCache_1__io_mem_cmd_payload_wr;
+      _zz_130_ <= dataCache_1__io_mem_cmd_payload_address;
+      _zz_131_ <= dataCache_1__io_mem_cmd_payload_data;
+      _zz_132_ <= dataCache_1__io_mem_cmd_payload_mask;
+      _zz_133_ <= dataCache_1__io_mem_cmd_payload_length;
+      _zz_134_ <= dataCache_1__io_mem_cmd_payload_last;
     end
     if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      _zz_139_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      _zz_140_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      _zz_141_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      _zz_142_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      _zz_143_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      _zz_144_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+      _zz_136_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
+      _zz_137_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
+      _zz_138_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
+      _zz_139_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
+      _zz_140_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
+      _zz_141_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
     end
-    if(_zz_176_)begin
-      _zz_178_ <= _zz_59_[11 : 7];
-      _zz_179_ <= _zz_91_;
+    if(_zz_173_)begin
+      _zz_175_ <= _zz_60_[11 : 7];
+      _zz_176_ <= _zz_92_;
     end
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
@@ -5707,9 +5638,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + (64'b0000000000000000000000000000000000000000000000000000000000000001));
     end
-    if(_zz_261_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_206_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_206_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_253_)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_197_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_197_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(BranchPlugin_branchExceptionPort_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
@@ -5719,21 +5650,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_278_)begin
-      if(_zz_279_)begin
+    if(_zz_270_)begin
+      if(_zz_271_)begin
         CsrPlugin_interrupt_code <= (4'b0111);
         CsrPlugin_interrupt_targetPrivilege <= (2'b11);
       end
-      if(_zz_280_)begin
+      if(_zz_272_)begin
         CsrPlugin_interrupt_code <= (4'b0011);
         CsrPlugin_interrupt_targetPrivilege <= (2'b11);
       end
-      if(_zz_281_)begin
+      if(_zz_273_)begin
         CsrPlugin_interrupt_code <= (4'b1011);
         CsrPlugin_interrupt_targetPrivilege <= (2'b11);
       end
     end
-    if(_zz_263_)begin
+    if(_zz_255_)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5753,66 +5684,73 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_256_)begin
-      if(_zz_262_)begin
-        memory_DivPlugin_rs1[31 : 0] <= _zz_360_[31:0];
-        memory_DivPlugin_accumulator[31 : 0] <= ((! _zz_209_[32]) ? _zz_361_ : _zz_362_);
+    if(_zz_248_)begin
+      if(_zz_254_)begin
+        memory_DivPlugin_rs1[31 : 0] <= _zz_351_[31:0];
+        memory_DivPlugin_accumulator[31 : 0] <= ((! _zz_200_[32]) ? _zz_352_ : _zz_353_);
         if((memory_DivPlugin_div_counter_value == (6'b100000)))begin
-          memory_DivPlugin_div_result <= _zz_363_[31:0];
+          memory_DivPlugin_div_result <= _zz_354_[31:0];
         end
       end
     end
-    if(_zz_275_)begin
+    if(_zz_267_)begin
       memory_DivPlugin_accumulator <= (65'b00000000000000000000000000000000000000000000000000000000000000000);
-      memory_DivPlugin_rs1 <= ((_zz_212_ ? (~ _zz_213_) : _zz_213_) + _zz_369_);
-      memory_DivPlugin_rs2 <= ((_zz_211_ ? (~ execute_RS2) : execute_RS2) + _zz_371_);
-      memory_DivPlugin_div_needRevert <= ((_zz_212_ ^ (_zz_211_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == (32'b00000000000000000000000000000000)) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_203_ ? (~ _zz_204_) : _zz_204_) + _zz_360_);
+      memory_DivPlugin_rs2 <= ((_zz_202_ ? (~ execute_RS2) : execute_RS2) + _zz_362_);
+      memory_DivPlugin_div_needRevert <= ((_zz_203_ ^ (_zz_202_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == (32'b00000000000000000000000000000000)) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_25_;
+      decode_to_execute_ALU_CTRL <= _zz_26_;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_23_;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_20_;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_43_;
+    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_PREDICTION_CONTEXT_hazard <= decode_PREDICTION_CONTEXT_hazard;
+      decode_to_execute_PREDICTION_CONTEXT_hit <= decode_PREDICTION_CONTEXT_hit;
+      decode_to_execute_PREDICTION_CONTEXT_line_source <= decode_PREDICTION_CONTEXT_line_source;
+      decode_to_execute_PREDICTION_CONTEXT_line_branchWish <= decode_PREDICTION_CONTEXT_line_branchWish;
+      decode_to_execute_PREDICTION_CONTEXT_line_target <= decode_PREDICTION_CONTEXT_line_target;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_42_;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_18_;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_ENV_CTRL <= _zz_15_;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      execute_to_memory_ENV_CTRL <= _zz_12_;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_10_;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -5824,61 +5762,13 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_99_;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_98_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_22_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_19_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_17_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_50_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_15_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
@@ -5887,25 +5777,7 @@ module VexRiscv (
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_12_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_10_;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -5917,13 +5789,88 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_7_;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_4_;
+      execute_to_memory_PC <= _zz_51_;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_8_;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_5_;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_2_;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_105_;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_104_;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
@@ -5933,24 +5880,6 @@ module VexRiscv (
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_2_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
     case(execute_CsrPlugin_csrAddress)
       12'b101111000000 : begin
@@ -5970,7 +5899,7 @@ module VexRiscv (
       end
       12'b001101000100 : begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mip_MSIP <= _zz_374_[0];
+          CsrPlugin_mip_MSIP <= _zz_365_[0];
         end
       end
       12'b110011000000 : begin

--- a/VexRiscv_IMA.yaml
+++ b/VexRiscv_IMA.yaml
@@ -1,4 +1,4 @@
 iBus: !!vexriscv.BusReport
   flushInstructions: [4111, 19, 19, 19]
-  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 4096}
+  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 8192}
   kind: cached


### PR DESCRIPTION
# Summary
Modified VexRiscv_IMA variant with the following items:
- Changed from static branch prediction to dynamic with branch target buffer (`DYNAMIC_TARGET`).
- Doubled I-cache and D-cache sizes from 4096 to 8192.
- Enable early branch; Branch in Execute stage instead of Memory stage.

To generate the verilog, `GenCoreDefault.scala` is updated by adding addition options:
- `earlyBranch`
- `singleCycleShift`

Additional fix in `GenCoreDefault.scala`:
- `memoryTranslatorPortConfig` parameter of IBus/DBus plugins is explicitly set to `null` when __not__ building a linux CPU.

Finally, the generated files for VexRiscv_IMA variant (`VexRiscxv_IMA.v` & `VexRiscv_IMA.yaml) are updated.