### PR TITLE
VexRiscv: Bump to 1.6.0 version of Spinal-HDL

### DIFF
--- a/VexRiscv_IMA.v
+++ b/VexRiscv_IMA.v
@@ -1,3599 +1,2595 @@
-// Generator : SpinalHDL v1.3.5    git head : f0505d24810c8661a24530409359554b7cfa271a
-// Date      : 27/08/2021, 17:47:19
+// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
 // Component : VexRiscv
+// Git hash  : c9b632b80fabad30bc4b847d27c16428ff12cb99
 
 
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define EnvCtrlEnum_binary_sequential_type [0:0]
+`define EnvCtrlEnum_binary_sequential_NONE 1'b0
+`define EnvCtrlEnum_binary_sequential_XRET 1'b1
 
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
+`define BranchCtrlEnum_binary_sequential_type [1:0]
+`define BranchCtrlEnum_binary_sequential_INC 2'b00
+`define BranchCtrlEnum_binary_sequential_B 2'b01
+`define BranchCtrlEnum_binary_sequential_JAL 2'b10
+`define BranchCtrlEnum_binary_sequential_JALR 2'b11
 
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+`define ShiftCtrlEnum_binary_sequential_type [1:0]
+`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
+`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
+`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
+`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
 
-`define EnvCtrlEnum_defaultEncoding_type [0:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 1'b0
-`define EnvCtrlEnum_defaultEncoding_XRET 1'b1
+`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
+`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
+`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
 
-`define BranchCtrlEnum_defaultEncoding_type [1:0]
-`define BranchCtrlEnum_defaultEncoding_INC 2'b00
-`define BranchCtrlEnum_defaultEncoding_B 2'b01
-`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
-`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
+`define Src2CtrlEnum_binary_sequential_type [1:0]
+`define Src2CtrlEnum_binary_sequential_RS 2'b00
+`define Src2CtrlEnum_binary_sequential_IMI 2'b01
+`define Src2CtrlEnum_binary_sequential_IMS 2'b10
+`define Src2CtrlEnum_binary_sequential_PC 2'b11
 
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define AluCtrlEnum_binary_sequential_type [1:0]
+`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
+`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
+`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
 
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+`define Src1CtrlEnum_binary_sequential_type [1:0]
+`define Src1CtrlEnum_binary_sequential_RS 2'b00
+`define Src1CtrlEnum_binary_sequential_IMU 2'b01
+`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_binary_sequential_URS1 2'b11
 
-module InstructionCache (
-      input   io_flush,
-      input   io_cpu_prefetch_isValid,
-      output reg  io_cpu_prefetch_haltIt,
-      input  [31:0] io_cpu_prefetch_pc,
-      input   io_cpu_fetch_isValid,
-      input   io_cpu_fetch_isStuck,
-      input   io_cpu_fetch_isRemoved,
-      input  [31:0] io_cpu_fetch_pc,
-      output [31:0] io_cpu_fetch_data,
-      input   io_cpu_fetch_dataBypassValid,
-      input  [31:0] io_cpu_fetch_dataBypass,
-      output  io_cpu_fetch_mmuBus_cmd_isValid,
-      output [31:0] io_cpu_fetch_mmuBus_cmd_virtualAddress,
-      output  io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-      input  [31:0] io_cpu_fetch_mmuBus_rsp_physicalAddress,
-      input   io_cpu_fetch_mmuBus_rsp_isIoAccess,
-      input   io_cpu_fetch_mmuBus_rsp_allowRead,
-      input   io_cpu_fetch_mmuBus_rsp_allowWrite,
-      input   io_cpu_fetch_mmuBus_rsp_allowExecute,
-      input   io_cpu_fetch_mmuBus_rsp_exception,
-      input   io_cpu_fetch_mmuBus_rsp_refilling,
-      output  io_cpu_fetch_mmuBus_end,
-      input   io_cpu_fetch_mmuBus_busy,
-      output [31:0] io_cpu_fetch_physicalAddress,
-      output  io_cpu_fetch_haltIt,
-      input   io_cpu_decode_isValid,
-      input   io_cpu_decode_isStuck,
-      input  [31:0] io_cpu_decode_pc,
-      output [31:0] io_cpu_decode_physicalAddress,
-      output [31:0] io_cpu_decode_data,
-      output  io_cpu_decode_cacheMiss,
-      output  io_cpu_decode_error,
-      output  io_cpu_decode_mmuRefilling,
-      output  io_cpu_decode_mmuException,
-      input   io_cpu_decode_isUser,
-      input   io_cpu_fill_valid,
-      input  [31:0] io_cpu_fill_payload,
-      output  io_mem_cmd_valid,
-      input   io_mem_cmd_ready,
-      output [31:0] io_mem_cmd_payload_address,
-      output [2:0] io_mem_cmd_payload_size,
-      input   io_mem_rsp_valid,
-      input  [31:0] io_mem_rsp_payload_data,
-      input   io_mem_rsp_payload_error,
-      input   clk,
-      input   reset);
-  reg [20:0] _zz_10_;
-  reg [31:0] _zz_11_;
-  wire  _zz_12_;
-  wire  _zz_13_;
-  wire [0:0] _zz_14_;
-  wire [0:0] _zz_15_;
-  wire [20:0] _zz_16_;
-  reg  _zz_1_;
-  reg  _zz_2_;
-  reg  lineLoader_fire;
-  reg  lineLoader_valid;
-  reg [31:0] lineLoader_address;
-  reg  lineLoader_hadError;
-  reg  lineLoader_flushPending;
-  reg [8:0] lineLoader_flushCounter;
-  reg  _zz_3_;
-  reg  lineLoader_cmdSent;
-  reg  lineLoader_wayToAllocate_willIncrement;
-  wire  lineLoader_wayToAllocate_willClear;
-  wire  lineLoader_wayToAllocate_willOverflowIfInc;
-  wire  lineLoader_wayToAllocate_willOverflow;
-  reg [2:0] lineLoader_wordIndex;
-  wire  lineLoader_write_tag_0_valid;
-  wire [7:0] lineLoader_write_tag_0_payload_address;
-  wire  lineLoader_write_tag_0_payload_data_valid;
-  wire  lineLoader_write_tag_0_payload_data_error;
-  wire [18:0] lineLoader_write_tag_0_payload_data_address;
-  wire  lineLoader_write_data_0_valid;
-  wire [10:0] lineLoader_write_data_0_payload_address;
-  wire [31:0] lineLoader_write_data_0_payload_data;
-  wire  _zz_4_;
-  wire [7:0] _zz_5_;
-  wire  _zz_6_;
-  wire  fetchStage_read_waysValues_0_tag_valid;
-  wire  fetchStage_read_waysValues_0_tag_error;
-  wire [18:0] fetchStage_read_waysValues_0_tag_address;
-  wire [20:0] _zz_7_;
-  wire [10:0] _zz_8_;
-  wire  _zz_9_;
-  wire [31:0] fetchStage_read_waysValues_0_data;
-  wire  fetchStage_hit_hits_0;
-  wire  fetchStage_hit_valid;
-  wire  fetchStage_hit_error;
-  wire [31:0] fetchStage_hit_data;
-  wire [31:0] fetchStage_hit_word;
-  reg [31:0] io_cpu_fetch_data_regNextWhen;
-  reg [31:0] decodeStage_mmuRsp_physicalAddress;
-  reg  decodeStage_mmuRsp_isIoAccess;
-  reg  decodeStage_mmuRsp_allowRead;
-  reg  decodeStage_mmuRsp_allowWrite;
-  reg  decodeStage_mmuRsp_allowExecute;
-  reg  decodeStage_mmuRsp_exception;
-  reg  decodeStage_mmuRsp_refilling;
-  reg  decodeStage_hit_valid;
-  reg  decodeStage_hit_error;
-  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:2047];
-  assign _zz_12_ = (! lineLoader_flushCounter[8]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],(5'b00000)};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(lineLoader_fire)begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[8]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[8] ? lineLoader_address[12 : 5] : lineLoader_flushCounter[7 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[8];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 13];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[12 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[12 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[20 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[12 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 13]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data[31 : 0];
-  assign io_cpu_fetch_data = (io_cpu_fetch_dataBypassValid ? io_cpu_fetch_dataBypass : fetchStage_hit_word);
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + (9'b000000001));
-    end
-    _zz_3_ <= lineLoader_flushCounter[8];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= (9'b000000000);
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-endmodule
-
-module DataCache (
-      input   io_cpu_execute_isValid,
-      input  [31:0] io_cpu_execute_address,
-      input   io_cpu_execute_args_wr,
-      input  [31:0] io_cpu_execute_args_data,
-      input  [1:0] io_cpu_execute_args_size,
-      input   io_cpu_execute_args_isLrsc,
-      input   io_cpu_execute_args_isAmo,
-      input   io_cpu_execute_args_amoCtrl_swap,
-      input  [2:0] io_cpu_execute_args_amoCtrl_alu,
-      input   io_cpu_memory_isValid,
-      input   io_cpu_memory_isStuck,
-      input   io_cpu_memory_isRemoved,
-      output  io_cpu_memory_isWrite,
-      input  [31:0] io_cpu_memory_address,
-      output  io_cpu_memory_mmuBus_cmd_isValid,
-      output [31:0] io_cpu_memory_mmuBus_cmd_virtualAddress,
-      output  io_cpu_memory_mmuBus_cmd_bypassTranslation,
-      input  [31:0] io_cpu_memory_mmuBus_rsp_physicalAddress,
-      input   io_cpu_memory_mmuBus_rsp_isIoAccess,
-      input   io_cpu_memory_mmuBus_rsp_allowRead,
-      input   io_cpu_memory_mmuBus_rsp_allowWrite,
-      input   io_cpu_memory_mmuBus_rsp_allowExecute,
-      input   io_cpu_memory_mmuBus_rsp_exception,
-      input   io_cpu_memory_mmuBus_rsp_refilling,
-      output  io_cpu_memory_mmuBus_end,
-      input   io_cpu_memory_mmuBus_busy,
-      input   io_cpu_writeBack_isValid,
-      input   io_cpu_writeBack_isStuck,
-      input   io_cpu_writeBack_isUser,
-      output reg  io_cpu_writeBack_haltIt,
-      output  io_cpu_writeBack_isWrite,
-      output reg [31:0] io_cpu_writeBack_data,
-      input  [31:0] io_cpu_writeBack_address,
-      output  io_cpu_writeBack_mmuException,
-      output  io_cpu_writeBack_unalignedAccess,
-      output reg  io_cpu_writeBack_accessError,
-      input   io_cpu_writeBack_clearLrsc,
-      output reg  io_cpu_redo,
-      input   io_cpu_flush_valid,
-      output reg  io_cpu_flush_ready,
-      output reg  io_mem_cmd_valid,
-      input   io_mem_cmd_ready,
-      output reg  io_mem_cmd_payload_wr,
-      output reg [31:0] io_mem_cmd_payload_address,
-      output [31:0] io_mem_cmd_payload_data,
-      output [3:0] io_mem_cmd_payload_mask,
-      output reg [2:0] io_mem_cmd_payload_length,
-      output reg  io_mem_cmd_payload_last,
-      input   io_mem_rsp_valid,
-      input  [31:0] io_mem_rsp_payload_data,
-      input   io_mem_rsp_payload_error,
-      input   clk,
-      input   reset);
-  reg [20:0] _zz_10_;
-  reg [31:0] _zz_11_;
-  wire  _zz_12_;
-  wire  _zz_13_;
-  wire  _zz_14_;
-  wire  _zz_15_;
-  wire  _zz_16_;
-  wire  _zz_17_;
-  wire  _zz_18_;
-  wire  _zz_19_;
-  wire  _zz_20_;
-  wire  _zz_21_;
-  wire [2:0] _zz_22_;
-  wire [0:0] _zz_23_;
-  wire [0:0] _zz_24_;
-  wire [31:0] _zz_25_;
-  wire [31:0] _zz_26_;
-  wire [31:0] _zz_27_;
-  wire [31:0] _zz_28_;
-  wire [1:0] _zz_29_;
-  wire [31:0] _zz_30_;
-  wire [1:0] _zz_31_;
-  wire [1:0] _zz_32_;
-  wire [0:0] _zz_33_;
-  wire [0:0] _zz_34_;
-  wire [2:0] _zz_35_;
-  wire [1:0] _zz_36_;
-  wire [20:0] _zz_37_;
-  reg  _zz_1_;
-  reg  _zz_2_;
-  wire  haltCpu;
-  reg  tagsReadCmd_valid;
-  reg [7:0] tagsReadCmd_payload;
-  reg  tagsWriteCmd_valid;
-  reg [0:0] tagsWriteCmd_payload_way;
-  reg [7:0] tagsWriteCmd_payload_address;
-  reg  tagsWriteCmd_payload_data_valid;
-  reg  tagsWriteCmd_payload_data_error;
-  reg [18:0] tagsWriteCmd_payload_data_address;
-  reg  tagsWriteLastCmd_valid;
-  reg [0:0] tagsWriteLastCmd_payload_way;
-  reg [7:0] tagsWriteLastCmd_payload_address;
-  reg  tagsWriteLastCmd_payload_data_valid;
-  reg  tagsWriteLastCmd_payload_data_error;
-  reg [18:0] tagsWriteLastCmd_payload_data_address;
-  reg  dataReadCmd_valid;
-  reg [10:0] dataReadCmd_payload;
-  reg  dataWriteCmd_valid;
-  reg [0:0] dataWriteCmd_payload_way;
-  reg [10:0] dataWriteCmd_payload_address;
-  reg [31:0] dataWriteCmd_payload_data;
-  reg [3:0] dataWriteCmd_payload_mask;
-  wire  _zz_3_;
-  wire  ways_0_tagsReadRsp_valid;
-  wire  ways_0_tagsReadRsp_error;
-  wire [18:0] ways_0_tagsReadRsp_address;
-  wire [20:0] _zz_4_;
-  wire  _zz_5_;
-  wire [31:0] ways_0_dataReadRsp;
-  reg [3:0] _zz_6_;
-  wire [3:0] stage0_mask;
-  wire [0:0] stage0_colisions;
-  reg  stageA_request_wr;
-  reg [31:0] stageA_request_data;
-  reg [1:0] stageA_request_size;
-  reg  stageA_request_isLrsc;
-  reg  stageA_request_isAmo;
-  reg  stageA_request_amoCtrl_swap;
-  reg [2:0] stageA_request_amoCtrl_alu;
-  reg [3:0] stageA_mask;
-  wire  stageA_wayHits_0;
-  reg [0:0] stage0_colisions_regNextWhen;
-  wire [0:0] _zz_7_;
-  wire [0:0] stageA_colisions;
-  reg  stageB_request_wr;
-  reg [31:0] stageB_request_data;
-  reg [1:0] stageB_request_size;
-  reg  stageB_request_isLrsc;
-  reg  stageB_isAmo;
-  reg  stageB_request_amoCtrl_swap;
-  reg [2:0] stageB_request_amoCtrl_alu;
-  reg  stageB_mmuRspFreeze;
-  reg [31:0] stageB_mmuRsp_physicalAddress;
-  reg  stageB_mmuRsp_isIoAccess;
-  reg  stageB_mmuRsp_allowRead;
-  reg  stageB_mmuRsp_allowWrite;
-  reg  stageB_mmuRsp_allowExecute;
-  reg  stageB_mmuRsp_exception;
-  reg  stageB_mmuRsp_refilling;
-  reg  stageB_tagsReadRsp_0_valid;
-  reg  stageB_tagsReadRsp_0_error;
-  reg [18:0] stageB_tagsReadRsp_0_address;
-  reg [31:0] stageB_dataReadRsp_0;
-  wire [0:0] _zz_8_;
-  reg [0:0] stageB_waysHits;
-  wire  stageB_waysHit;
-  wire [31:0] stageB_dataMux;
-  reg [3:0] stageB_mask;
-  reg [0:0] stageB_colisions;
-  reg  stageB_loaderValid;
-  reg  stageB_flusher_valid;
-  reg  stageB_lrsc_reserved;
-  reg [31:0] stageB_requestDataBypass;
-  wire  stageB_amo_compare;
-  wire  stageB_amo_unsigned;
-  wire [31:0] stageB_amo_addSub;
-  wire  stageB_amo_less;
-  wire  stageB_amo_selectRf;
-  reg [31:0] stageB_amo_result;
-  reg  stageB_amo_resultRegValid;
-  reg [31:0] stageB_amo_resultReg;
-  reg  stageB_memCmdSent;
-  wire [0:0] _zz_9_;
-  reg  loader_valid;
-  reg  loader_counter_willIncrement;
-  wire  loader_counter_willClear;
-  reg [2:0] loader_counter_valueNext;
-  reg [2:0] loader_counter_value;
-  wire  loader_counter_willOverflowIfInc;
-  wire  loader_counter_willOverflow;
-  reg [0:0] loader_waysAllocator;
-  reg  loader_error;
-  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
-  reg [7:0] _zz_38_;
-  reg [7:0] _zz_39_;
-  reg [7:0] _zz_40_;
-  reg [7:0] _zz_41_;
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (! stageB_amo_resultRegValid);
-  assign _zz_16_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_17_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_18_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_19_ = ((((io_cpu_flush_valid && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-  assign _zz_20_ = (((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0)));
-  assign _zz_21_ = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign _zz_22_ = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,(2'b00)});
-  assign _zz_23_ = _zz_4_[0 : 0];
-  assign _zz_24_ = _zz_4_[1 : 1];
-  assign _zz_25_ = ($signed(_zz_26_) + $signed(_zz_30_));
-  assign _zz_26_ = ($signed(_zz_27_) + $signed(_zz_28_));
-  assign _zz_27_ = stageB_request_data;
-  assign _zz_28_ = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_29_ = (stageB_amo_compare ? _zz_31_ : _zz_32_);
-  assign _zz_30_ = {{30{_zz_29_[1]}}, _zz_29_};
-  assign _zz_31_ = (2'b01);
-  assign _zz_32_ = (2'b00);
-  assign _zz_33_ = (! stageB_lrsc_reserved);
-  assign _zz_34_ = loader_counter_willIncrement;
-  assign _zz_35_ = {2'd0, _zz_34_};
-  assign _zz_36_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_37_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_37_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_41_, _zz_40_, _zz_39_, _zz_38_};
-  end
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_38_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_39_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_40_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_41_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_23_[0];
-  assign ways_0_tagsReadRsp_error = _zz_24_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[20 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = (8'bxxxxxxxx);
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[12 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = (11'bxxxxxxxxxxx);
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[12 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = (8'bxxxxxxxx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = (19'bxxxxxxxxxxxxxxxxxxx);
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 13];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-          if(stageB_isAmo)begin
-            if(_zz_15_)begin
-              dataWriteCmd_valid = 1'b0;
-            end
-          end
-          if(_zz_16_)begin
-            dataWriteCmd_valid = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = (11'bxxxxxxxxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 2];
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[12 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = (32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[12 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 13] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[12 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-        if(_zz_18_)begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-          if(stageB_isAmo)begin
-            if(_zz_15_)begin
-              io_cpu_writeBack_haltIt = 1'b1;
-            end
-          end
-          if(_zz_16_)begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(_zz_19_)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
-    end
-  end
-
-  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
-  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == (2'b11));
-  assign stageB_amo_addSub = _zz_25_;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
-  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_22_)
-      3'b000 : begin
-        stageB_amo_result = stageB_amo_addSub;
-      end
-      3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
-      end
-      3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
-      end
-      3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
-      end
-      default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if(_zz_20_)begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-        if(_zz_18_)begin
-          io_mem_cmd_valid = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-          if(stageB_isAmo)begin
-            if(_zz_15_)begin
-              io_mem_cmd_valid = 1'b0;
-            end
-          end
-          if(_zz_20_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-          if(_zz_16_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = (32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],(5'b00000)};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_33_};
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_17_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_35_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
-      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
-      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
-      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-      stageB_request_isLrsc <= stageA_request_isLrsc;
-      stageB_isAmo <= stageA_request_isAmo;
-      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
-      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
-    end
-    if(_zz_21_)begin
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    stageB_amo_resultRegValid <= 1'b1;
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_amo_resultRegValid <= 1'b0;
-    end
-    stageB_amo_resultReg <= stageB_amo_result;
-    if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-      $display("ERROR writeBack stuck by another plugin is not allowed");
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b1;
-      stageB_mmuRsp_physicalAddress <= (32'b00000000000000000000000000000000);
-      stageB_lrsc_reserved <= 1'b0;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(_zz_21_)begin
-        stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      end
-      if(stageB_flusher_valid)begin
-        if((stageB_mmuRsp_physicalAddress[12 : 5] != (8'b11111111)))begin
-          stageB_mmuRsp_physicalAddress[12 : 5] <= (stageB_mmuRsp_physicalAddress[12 : 5] + (8'b00000001));
-        end else begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      if(_zz_19_)begin
-        stageB_mmuRsp_physicalAddress[12 : 5] <= (8'b00000000);
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(((((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && (! io_cpu_redo)) && stageB_request_isLrsc) && (! stageB_request_wr)))begin
-        stageB_lrsc_reserved <= 1'b1;
-      end
-      if(io_cpu_writeBack_clearLrsc)begin
-        stageB_lrsc_reserved <= 1'b0;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_17_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_waysAllocator <= _zz_36_[0:0];
-        loader_error <= 1'b0;
-      end
-    end
-  end
-
-endmodule
 
 module VexRiscv (
-      input  [31:0] externalResetVector,
-      input   timerInterrupt,
-      input   softwareInterrupt,
-      input  [31:0] externalInterruptArray,
-      output reg  iBusWishbone_CYC,
-      output reg  iBusWishbone_STB,
-      input   iBusWishbone_ACK,
-      output  iBusWishbone_WE,
-      output [29:0] iBusWishbone_ADR,
-      input  [31:0] iBusWishbone_DAT_MISO,
-      output [31:0] iBusWishbone_DAT_MOSI,
-      output [3:0] iBusWishbone_SEL,
-      input   iBusWishbone_ERR,
-      output [1:0] iBusWishbone_BTE,
-      output [2:0] iBusWishbone_CTI,
-      output  dBusWishbone_CYC,
-      output  dBusWishbone_STB,
-      input   dBusWishbone_ACK,
-      output  dBusWishbone_WE,
-      output [29:0] dBusWishbone_ADR,
-      input  [31:0] dBusWishbone_DAT_MISO,
-      output [31:0] dBusWishbone_DAT_MOSI,
-      output [3:0] dBusWishbone_SEL,
-      input   dBusWishbone_ERR,
-      output [1:0] dBusWishbone_BTE,
-      output [2:0] dBusWishbone_CTI,
-      input   clk,
-      input   reset);
-  wire  _zz_216_;
-  wire  _zz_217_;
-  wire  _zz_218_;
-  wire  _zz_219_;
-  wire  _zz_220_;
-  wire [31:0] _zz_221_;
-  wire  _zz_222_;
-  wire  _zz_223_;
-  wire  _zz_224_;
-  reg  _zz_225_;
-  wire  _zz_226_;
-  wire [31:0] _zz_227_;
-  reg  _zz_228_;
-  wire  _zz_229_;
-  wire [2:0] _zz_230_;
-  wire  _zz_231_;
-  wire [31:0] _zz_232_;
-  reg  _zz_233_;
-  wire  _zz_234_;
-  wire  _zz_235_;
-  wire [31:0] _zz_236_;
-  wire  _zz_237_;
-  wire  _zz_238_;
-  reg [53:0] _zz_239_;
-  reg [31:0] _zz_240_;
-  reg [31:0] _zz_241_;
-  reg [31:0] _zz_242_;
-  wire  IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
-  wire [31:0] IBusCachedPlugin_cache_io_cpu_fetch_data;
-  wire [31:0] IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire  IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire  IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire [31:0] IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire  IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire  IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  wire  IBusCachedPlugin_cache_io_cpu_decode_error;
-  wire  IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
-  wire  IBusCachedPlugin_cache_io_cpu_decode_mmuException;
-  wire [31:0] IBusCachedPlugin_cache_io_cpu_decode_data;
-  wire  IBusCachedPlugin_cache_io_cpu_decode_cacheMiss;
-  wire [31:0] IBusCachedPlugin_cache_io_cpu_decode_physicalAddress;
-  wire  IBusCachedPlugin_cache_io_mem_cmd_valid;
-  wire [31:0] IBusCachedPlugin_cache_io_mem_cmd_payload_address;
-  wire [2:0] IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire  dataCache_1__io_cpu_memory_isWrite;
-  wire  dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire [31:0] dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire  dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire  dataCache_1__io_cpu_memory_mmuBus_end;
-  wire  dataCache_1__io_cpu_writeBack_haltIt;
-  wire [31:0] dataCache_1__io_cpu_writeBack_data;
-  wire  dataCache_1__io_cpu_writeBack_mmuException;
-  wire  dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire  dataCache_1__io_cpu_writeBack_accessError;
-  wire  dataCache_1__io_cpu_writeBack_isWrite;
-  wire  dataCache_1__io_cpu_flush_ready;
-  wire  dataCache_1__io_cpu_redo;
-  wire  dataCache_1__io_mem_cmd_valid;
-  wire  dataCache_1__io_mem_cmd_payload_wr;
-  wire [31:0] dataCache_1__io_mem_cmd_payload_address;
-  wire [31:0] dataCache_1__io_mem_cmd_payload_data;
-  wire [3:0] dataCache_1__io_mem_cmd_payload_mask;
-  wire [2:0] dataCache_1__io_mem_cmd_payload_length;
-  wire  dataCache_1__io_mem_cmd_payload_last;
-  wire  _zz_243_;
-  wire  _zz_244_;
-  wire  _zz_245_;
-  wire  _zz_246_;
-  wire  _zz_247_;
-  wire  _zz_248_;
-  wire  _zz_249_;
-  wire  _zz_250_;
-  wire  _zz_251_;
-  wire  _zz_252_;
-  wire  _zz_253_;
-  wire  _zz_254_;
-  wire  _zz_255_;
-  wire  _zz_256_;
-  wire [1:0] _zz_257_;
-  wire  _zz_258_;
-  wire  _zz_259_;
-  wire  _zz_260_;
-  wire  _zz_261_;
-  wire  _zz_262_;
-  wire  _zz_263_;
-  wire  _zz_264_;
-  wire  _zz_265_;
-  wire [1:0] _zz_266_;
-  wire  _zz_267_;
-  wire  _zz_268_;
-  wire  _zz_269_;
-  wire  _zz_270_;
-  wire  _zz_271_;
-  wire  _zz_272_;
-  wire  _zz_273_;
-  wire [1:0] _zz_274_;
-  wire  _zz_275_;
-  wire [1:0] _zz_276_;
-  wire [3:0] _zz_277_;
-  wire [2:0] _zz_278_;
-  wire [31:0] _zz_279_;
-  wire [9:0] _zz_280_;
-  wire [19:0] _zz_281_;
-  wire [29:0] _zz_282_;
-  wire [9:0] _zz_283_;
-  wire [1:0] _zz_284_;
-  wire [0:0] _zz_285_;
-  wire [1:0] _zz_286_;
-  wire [0:0] _zz_287_;
-  wire [1:0] _zz_288_;
-  wire [1:0] _zz_289_;
-  wire [0:0] _zz_290_;
-  wire [1:0] _zz_291_;
-  wire [0:0] _zz_292_;
-  wire [1:0] _zz_293_;
-  wire [2:0] _zz_294_;
-  wire [2:0] _zz_295_;
-  wire [0:0] _zz_296_;
-  wire [0:0] _zz_297_;
-  wire [0:0] _zz_298_;
-  wire [0:0] _zz_299_;
-  wire [0:0] _zz_300_;
-  wire [0:0] _zz_301_;
-  wire [0:0] _zz_302_;
-  wire [0:0] _zz_303_;
-  wire [0:0] _zz_304_;
-  wire [0:0] _zz_305_;
-  wire [0:0] _zz_306_;
-  wire [0:0] _zz_307_;
-  wire [0:0] _zz_308_;
-  wire [0:0] _zz_309_;
-  wire [0:0] _zz_310_;
-  wire [0:0] _zz_311_;
-  wire [0:0] _zz_312_;
-  wire [0:0] _zz_313_;
-  wire [0:0] _zz_314_;
-  wire [0:0] _zz_315_;
-  wire [2:0] _zz_316_;
-  wire [4:0] _zz_317_;
-  wire [11:0] _zz_318_;
-  wire [11:0] _zz_319_;
-  wire [31:0] _zz_320_;
-  wire [31:0] _zz_321_;
-  wire [31:0] _zz_322_;
-  wire [31:0] _zz_323_;
-  wire [31:0] _zz_324_;
-  wire [31:0] _zz_325_;
-  wire [31:0] _zz_326_;
-  wire [32:0] _zz_327_;
-  wire [31:0] _zz_328_;
-  wire [32:0] _zz_329_;
-  wire [19:0] _zz_330_;
-  wire [11:0] _zz_331_;
-  wire [11:0] _zz_332_;
-  wire [1:0] _zz_333_;
-  wire [1:0] _zz_334_;
-  wire [51:0] _zz_335_;
-  wire [51:0] _zz_336_;
-  wire [51:0] _zz_337_;
-  wire [32:0] _zz_338_;
-  wire [51:0] _zz_339_;
-  wire [49:0] _zz_340_;
-  wire [51:0] _zz_341_;
-  wire [49:0] _zz_342_;
-  wire [51:0] _zz_343_;
-  wire [65:0] _zz_344_;
-  wire [65:0] _zz_345_;
-  wire [31:0] _zz_346_;
-  wire [31:0] _zz_347_;
-  wire [0:0] _zz_348_;
-  wire [5:0] _zz_349_;
-  wire [32:0] _zz_350_;
-  wire [32:0] _zz_351_;
-  wire [31:0] _zz_352_;
-  wire [31:0] _zz_353_;
-  wire [32:0] _zz_354_;
-  wire [32:0] _zz_355_;
-  wire [32:0] _zz_356_;
-  wire [0:0] _zz_357_;
-  wire [32:0] _zz_358_;
-  wire [0:0] _zz_359_;
-  wire [32:0] _zz_360_;
-  wire [0:0] _zz_361_;
-  wire [31:0] _zz_362_;
-  wire [0:0] _zz_363_;
-  wire [0:0] _zz_364_;
-  wire [0:0] _zz_365_;
-  wire [0:0] _zz_366_;
-  wire [0:0] _zz_367_;
-  wire [0:0] _zz_368_;
-  wire [26:0] _zz_369_;
-  wire [53:0] _zz_370_;
-  wire  _zz_371_;
-  wire  _zz_372_;
-  wire [1:0] _zz_373_;
-  wire [31:0] _zz_374_;
-  wire [0:0] _zz_375_;
-  wire [4:0] _zz_376_;
-  wire [0:0] _zz_377_;
-  wire [2:0] _zz_378_;
-  wire [1:0] _zz_379_;
-  wire [1:0] _zz_380_;
-  wire  _zz_381_;
-  wire [0:0] _zz_382_;
-  wire [26:0] _zz_383_;
-  wire [31:0] _zz_384_;
-  wire [31:0] _zz_385_;
-  wire  _zz_386_;
-  wire [0:0] _zz_387_;
-  wire [2:0] _zz_388_;
-  wire [31:0] _zz_389_;
-  wire [31:0] _zz_390_;
-  wire  _zz_391_;
-  wire [0:0] _zz_392_;
-  wire [0:0] _zz_393_;
-  wire  _zz_394_;
-  wire  _zz_395_;
-  wire [0:0] _zz_396_;
-  wire [1:0] _zz_397_;
-  wire [1:0] _zz_398_;
-  wire [1:0] _zz_399_;
-  wire  _zz_400_;
-  wire [0:0] _zz_401_;
-  wire [24:0] _zz_402_;
-  wire [31:0] _zz_403_;
-  wire [31:0] _zz_404_;
-  wire [31:0] _zz_405_;
-  wire  _zz_406_;
-  wire [0:0] _zz_407_;
-  wire [0:0] _zz_408_;
-  wire [31:0] _zz_409_;
-  wire [31:0] _zz_410_;
-  wire [31:0] _zz_411_;
-  wire [31:0] _zz_412_;
-  wire [31:0] _zz_413_;
-  wire [31:0] _zz_414_;
-  wire [31:0] _zz_415_;
-  wire [31:0] _zz_416_;
-  wire [31:0] _zz_417_;
-  wire  _zz_418_;
-  wire  _zz_419_;
-  wire  _zz_420_;
-  wire  _zz_421_;
-  wire [0:0] _zz_422_;
-  wire [0:0] _zz_423_;
-  wire  _zz_424_;
-  wire [0:0] _zz_425_;
-  wire [22:0] _zz_426_;
-  wire [31:0] _zz_427_;
-  wire [31:0] _zz_428_;
-  wire [31:0] _zz_429_;
-  wire [31:0] _zz_430_;
-  wire [31:0] _zz_431_;
-  wire [31:0] _zz_432_;
-  wire [31:0] _zz_433_;
-  wire [31:0] _zz_434_;
-  wire [31:0] _zz_435_;
-  wire  _zz_436_;
-  wire [0:0] _zz_437_;
-  wire [0:0] _zz_438_;
-  wire  _zz_439_;
-  wire [0:0] _zz_440_;
-  wire [20:0] _zz_441_;
-  wire  _zz_442_;
-  wire [0:0] _zz_443_;
-  wire [1:0] _zz_444_;
-  wire  _zz_445_;
-  wire [0:0] _zz_446_;
-  wire [2:0] _zz_447_;
-  wire  _zz_448_;
-  wire [0:0] _zz_449_;
-  wire [0:0] _zz_450_;
-  wire  _zz_451_;
-  wire [0:0] _zz_452_;
-  wire [16:0] _zz_453_;
-  wire [31:0] _zz_454_;
-  wire [31:0] _zz_455_;
-  wire [31:0] _zz_456_;
-  wire  _zz_457_;
-  wire  _zz_458_;
-  wire [31:0] _zz_459_;
-  wire [31:0] _zz_460_;
-  wire [31:0] _zz_461_;
-  wire  _zz_462_;
-  wire [0:0] _zz_463_;
-  wire [0:0] _zz_464_;
-  wire [31:0] _zz_465_;
-  wire [31:0] _zz_466_;
-  wire [31:0] _zz_467_;
-  wire [0:0] _zz_468_;
-  wire [1:0] _zz_469_;
-  wire [2:0] _zz_470_;
-  wire [2:0] _zz_471_;
-  wire  _zz_472_;
-  wire [0:0] _zz_473_;
-  wire [14:0] _zz_474_;
-  wire [31:0] _zz_475_;
-  wire [31:0] _zz_476_;
-  wire [31:0] _zz_477_;
-  wire [31:0] _zz_478_;
-  wire [31:0] _zz_479_;
-  wire [31:0] _zz_480_;
-  wire [31:0] _zz_481_;
-  wire  _zz_482_;
-  wire  _zz_483_;
-  wire  _zz_484_;
-  wire [0:0] _zz_485_;
-  wire [0:0] _zz_486_;
-  wire [0:0] _zz_487_;
-  wire [0:0] _zz_488_;
-  wire [1:0] _zz_489_;
-  wire [1:0] _zz_490_;
-  wire  _zz_491_;
-  wire [0:0] _zz_492_;
-  wire [12:0] _zz_493_;
-  wire [31:0] _zz_494_;
-  wire [31:0] _zz_495_;
-  wire [31:0] _zz_496_;
-  wire [31:0] _zz_497_;
-  wire [31:0] _zz_498_;
-  wire [31:0] _zz_499_;
-  wire [31:0] _zz_500_;
-  wire [31:0] _zz_501_;
-  wire [31:0] _zz_502_;
-  wire  _zz_503_;
-  wire [0:0] _zz_504_;
-  wire [1:0] _zz_505_;
-  wire [1:0] _zz_506_;
-  wire [1:0] _zz_507_;
-  wire  _zz_508_;
-  wire [0:0] _zz_509_;
-  wire [10:0] _zz_510_;
-  wire [31:0] _zz_511_;
-  wire [31:0] _zz_512_;
-  wire [31:0] _zz_513_;
-  wire [31:0] _zz_514_;
-  wire [31:0] _zz_515_;
-  wire [31:0] _zz_516_;
-  wire  _zz_517_;
-  wire [0:0] _zz_518_;
-  wire [0:0] _zz_519_;
-  wire  _zz_520_;
-  wire [0:0] _zz_521_;
-  wire [7:0] _zz_522_;
-  wire [31:0] _zz_523_;
-  wire  _zz_524_;
-  wire  _zz_525_;
-  wire [4:0] _zz_526_;
-  wire [4:0] _zz_527_;
-  wire  _zz_528_;
-  wire [0:0] _zz_529_;
-  wire [3:0] _zz_530_;
-  wire [31:0] _zz_531_;
-  wire [31:0] _zz_532_;
-  wire  _zz_533_;
-  wire [0:0] _zz_534_;
-  wire [1:0] _zz_535_;
-  wire [0:0] _zz_536_;
-  wire [0:0] _zz_537_;
-  wire [0:0] _zz_538_;
-  wire [0:0] _zz_539_;
-  wire  _zz_540_;
-  wire [0:0] _zz_541_;
-  wire [0:0] _zz_542_;
-  wire [31:0] _zz_543_;
-  wire [31:0] _zz_544_;
-  wire [31:0] _zz_545_;
-  wire [31:0] _zz_546_;
-  wire [31:0] _zz_547_;
-  wire [31:0] _zz_548_;
-  wire [31:0] _zz_549_;
-  wire [0:0] _zz_550_;
-  wire [2:0] _zz_551_;
-  wire [0:0] _zz_552_;
-  wire [0:0] _zz_553_;
-  wire [31:0] _zz_554_;
-  wire [31:0] _zz_555_;
-  wire [31:0] _zz_556_;
-  wire  _zz_557_;
-  wire [0:0] _zz_558_;
-  wire [14:0] _zz_559_;
-  wire [31:0] _zz_560_;
-  wire [31:0] _zz_561_;
-  wire [31:0] _zz_562_;
-  wire  _zz_563_;
-  wire [0:0] _zz_564_;
-  wire [8:0] _zz_565_;
-  wire [31:0] _zz_566_;
-  wire [31:0] _zz_567_;
-  wire [31:0] _zz_568_;
-  wire  _zz_569_;
-  wire [0:0] _zz_570_;
-  wire [2:0] _zz_571_;
-  wire  memory_IS_MUL;
-  wire  execute_IS_MUL;
-  wire  decode_IS_MUL;
-  wire [31:0] writeBack_FORMAL_PC_NEXT;
-  wire [31:0] memory_FORMAL_PC_NEXT;
-  wire [31:0] execute_FORMAL_PC_NEXT;
-  wire [31:0] decode_FORMAL_PC_NEXT;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_1_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_2_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_3_;
-  wire `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_4_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_5_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_6_;
-  wire [51:0] memory_MUL_LOW;
-  wire  decode_MEMORY_LRSC;
-  wire  decode_IS_RS1_SIGNED;
-  wire  decode_CSR_WRITE_OPCODE;
-  wire  decode_SRC2_FORCE_ZERO;
-  wire [33:0] execute_MUL_LH;
-  wire [31:0] execute_MUL_LL;
-  wire  decode_CSR_READ_OPCODE;
-  wire  decode_MEMORY_AMO;
-  wire [33:0] execute_MUL_HL;
-  wire  execute_BYPASSABLE_MEMORY_STAGE;
-  wire  decode_BYPASSABLE_MEMORY_STAGE;
-  wire  decode_MEMORY_MANAGMENT;
-  wire `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_7_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_8_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_9_;
-  wire  decode_IS_DIV;
-  wire [31:0] memory_PC;
-  wire  decode_BYPASSABLE_EXECUTE_STAGE;
-  wire  memory_MEMORY_WR;
-  wire  decode_MEMORY_WR;
-  wire [33:0] memory_MUL_HH;
-  wire [33:0] execute_MUL_HH;
-  wire [31:0] execute_SHIFT_RIGHT;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_10_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_11_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_12_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_13_;
-  wire `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_14_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_15_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_16_;
-  wire `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_17_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_18_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_19_;
-  wire  decode_IS_CSR;
-  wire [1:0] memory_MEMORY_ADDRESS_LOW;
-  wire [1:0] execute_MEMORY_ADDRESS_LOW;
-  wire  decode_PREDICTION_CONTEXT_hazard;
-  wire  decode_PREDICTION_CONTEXT_hit;
-  wire [19:0] decode_PREDICTION_CONTEXT_line_source;
-  wire [1:0] decode_PREDICTION_CONTEXT_line_branchWish;
-  wire [31:0] decode_PREDICTION_CONTEXT_line_target;
-  wire [31:0] execute_REGFILE_WRITE_DATA;
-  wire  decode_IS_RS2_SIGNED;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_20_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_21_;
-  wire `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_22_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_23_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_24_;
-  wire  decode_SRC_LESS_UNSIGNED;
-  wire `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_25_;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_26_;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_27_;
-  wire  execute_IS_RS1_SIGNED;
-  wire  execute_IS_DIV;
-  wire  execute_IS_RS2_SIGNED;
-  wire  memory_IS_DIV;
-  wire  writeBack_IS_MUL;
-  wire [33:0] writeBack_MUL_HH;
-  wire [51:0] writeBack_MUL_LOW;
-  wire [33:0] memory_MUL_HL;
-  wire [33:0] memory_MUL_LH;
-  wire [31:0] memory_MUL_LL;
-  wire [51:0] _zz_28_;
-  wire [33:0] _zz_29_;
-  wire [33:0] _zz_30_;
-  wire [33:0] _zz_31_;
-  wire [31:0] _zz_32_;
-  wire  execute_CSR_READ_OPCODE;
-  wire  execute_CSR_WRITE_OPCODE;
-  wire  execute_IS_CSR;
-  wire `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_33_;
-  wire `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_34_;
-  wire  _zz_35_;
-  wire  _zz_36_;
-  wire `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_37_;
-  wire [31:0] execute_NEXT_PC2;
-  wire  execute_TARGET_MISSMATCH2;
-  wire  execute_BRANCH_DO;
-  wire [31:0] execute_BRANCH_CALC;
-  wire  _zz_38_;
-  wire [31:0] _zz_39_;
-  wire [31:0] _zz_40_;
-  wire [31:0] execute_PC;
-  wire [31:0] execute_RS1;
-  wire `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_41_;
-  wire  _zz_42_;
-  wire  decode_RS2_USE;
-  wire  decode_RS1_USE;
-  reg [31:0] _zz_43_;
-  wire  execute_REGFILE_WRITE_VALID;
-  wire  execute_BYPASSABLE_EXECUTE_STAGE;
-  wire  memory_REGFILE_WRITE_VALID;
-  wire [31:0] memory_INSTRUCTION;
-  wire  memory_BYPASSABLE_MEMORY_STAGE;
-  wire  writeBack_REGFILE_WRITE_VALID;
-  reg [31:0] decode_RS2;
-  reg [31:0] decode_RS1;
-  wire [31:0] memory_SHIFT_RIGHT;
-  reg [31:0] _zz_44_;
-  wire `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_45_;
-  wire [31:0] _zz_46_;
-  wire `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_47_;
-  wire  _zz_48_;
-  wire [31:0] _zz_49_;
-  wire [31:0] _zz_50_;
-  wire  execute_SRC_LESS_UNSIGNED;
-  wire  execute_SRC2_FORCE_ZERO;
-  wire  execute_SRC_USE_SUB_LESS;
-  wire [31:0] _zz_51_;
-  wire `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_52_;
-  wire [31:0] _zz_53_;
-  wire `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_54_;
-  wire [31:0] _zz_55_;
-  wire  decode_SRC_USE_SUB_LESS;
-  wire  decode_SRC_ADD_ZERO;
-  wire  _zz_56_;
-  wire [31:0] execute_SRC_ADD_SUB;
-  wire  execute_SRC_LESS;
-  wire `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_57_;
-  wire [31:0] _zz_58_;
-  wire [31:0] execute_SRC2;
-  wire [31:0] execute_SRC1;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_59_;
-  wire [31:0] _zz_60_;
-  wire  _zz_61_;
-  reg  _zz_62_;
-  wire [31:0] _zz_63_;
-  wire [31:0] _zz_64_;
-  wire [31:0] decode_INSTRUCTION_ANTICIPATED;
-  reg  decode_REGFILE_WRITE_VALID;
-  wire  decode_LEGAL_INSTRUCTION;
-  wire  decode_INSTRUCTION_READY;
-  wire  _zz_65_;
-  wire  _zz_66_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_67_;
-  wire  _zz_68_;
-  wire  _zz_69_;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_70_;
-  wire  _zz_71_;
-  wire  _zz_72_;
-  wire  _zz_73_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_74_;
-  wire  _zz_75_;
-  wire  _zz_76_;
-  wire  _zz_77_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_78_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_79_;
-  wire  _zz_80_;
-  wire  _zz_81_;
-  wire  _zz_82_;
-  wire  _zz_83_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_84_;
-  wire  _zz_85_;
-  wire  _zz_86_;
-  wire  _zz_87_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_88_;
-  wire  _zz_89_;
-  wire  _zz_90_;
-  wire  _zz_91_;
-  reg [31:0] _zz_92_;
-  wire [1:0] writeBack_MEMORY_ADDRESS_LOW;
-  wire  writeBack_MEMORY_WR;
-  wire [31:0] writeBack_REGFILE_WRITE_DATA;
-  wire  writeBack_MEMORY_ENABLE;
-  wire [31:0] memory_REGFILE_WRITE_DATA;
-  wire  memory_MEMORY_ENABLE;
-  wire [1:0] _zz_93_;
-  wire  execute_MEMORY_AMO;
-  wire  execute_MEMORY_LRSC;
-  wire  execute_MEMORY_MANAGMENT;
-  wire [31:0] execute_RS2;
-  wire  execute_MEMORY_WR;
-  wire [31:0] execute_SRC_ADD;
-  wire  execute_MEMORY_ENABLE;
-  wire [31:0] execute_INSTRUCTION;
-  wire  decode_MEMORY_ENABLE;
-  wire  decode_FLUSH_ALL;
-  reg  IBusCachedPlugin_rsp_issueDetected;
-  reg  _zz_94_;
-  reg  _zz_95_;
-  reg  _zz_96_;
-  wire [31:0] decode_INSTRUCTION;
-  wire [31:0] _zz_97_;
-  wire  execute_PREDICTION_CONTEXT_hazard;
-  wire  execute_PREDICTION_CONTEXT_hit;
-  wire [19:0] execute_PREDICTION_CONTEXT_line_source;
-  wire [1:0] execute_PREDICTION_CONTEXT_line_branchWish;
-  wire [31:0] execute_PREDICTION_CONTEXT_line_target;
-  wire  _zz_98_;
-  wire  _zz_99_;
-  wire [19:0] _zz_100_;
-  wire [1:0] _zz_101_;
-  wire [31:0] _zz_102_;
-  reg  _zz_103_;
-  reg [31:0] _zz_104_;
-  reg [31:0] _zz_105_;
-  wire [31:0] decode_PC;
-  wire [31:0] _zz_106_;
-  wire [31:0] _zz_107_;
-  wire [31:0] _zz_108_;
-  wire [31:0] writeBack_PC;
-  wire [31:0] writeBack_INSTRUCTION;
-  reg  decode_arbitration_haltItself;
-  reg  decode_arbitration_haltByOther;
-  reg  decode_arbitration_removeIt;
-  reg  decode_arbitration_flushAll;
-  wire  decode_arbitration_isValid;
-  wire  decode_arbitration_isStuck;
-  wire  decode_arbitration_isStuckByOthers;
-  wire  decode_arbitration_isFlushed;
-  wire  decode_arbitration_isMoving;
-  wire  decode_arbitration_isFiring;
-  reg  execute_arbitration_haltItself;
-  wire  execute_arbitration_haltByOther;
-  reg  execute_arbitration_removeIt;
-  wire  execute_arbitration_flushAll;
-  reg  execute_arbitration_isValid;
-  wire  execute_arbitration_isStuck;
-  wire  execute_arbitration_isStuckByOthers;
-  wire  execute_arbitration_isFlushed;
-  wire  execute_arbitration_isMoving;
-  wire  execute_arbitration_isFiring;
-  reg  memory_arbitration_haltItself;
-  wire  memory_arbitration_haltByOther;
-  reg  memory_arbitration_removeIt;
-  reg  memory_arbitration_flushAll;
-  reg  memory_arbitration_isValid;
-  wire  memory_arbitration_isStuck;
-  wire  memory_arbitration_isStuckByOthers;
-  wire  memory_arbitration_isFlushed;
-  wire  memory_arbitration_isMoving;
-  wire  memory_arbitration_isFiring;
-  reg  writeBack_arbitration_haltItself;
-  wire  writeBack_arbitration_haltByOther;
-  reg  writeBack_arbitration_removeIt;
-  reg  writeBack_arbitration_flushAll;
-  reg  writeBack_arbitration_isValid;
-  wire  writeBack_arbitration_isStuck;
-  wire  writeBack_arbitration_isStuckByOthers;
-  wire  writeBack_arbitration_isFlushed;
-  wire  writeBack_arbitration_isMoving;
-  wire  writeBack_arbitration_isFiring;
-  wire [31:0] lastStageInstruction /* verilator public */ ;
-  wire [31:0] lastStagePc /* verilator public */ ;
-  wire  lastStageIsValid /* verilator public */ ;
-  wire  lastStageIsFiring /* verilator public */ ;
-  reg  IBusCachedPlugin_fetcherHalt;
-  wire  IBusCachedPlugin_fetcherflushIt;
-  reg  IBusCachedPlugin_incomingInstruction;
-  wire  IBusCachedPlugin_fetchPrediction_cmd_hadBranch;
-  wire [31:0] IBusCachedPlugin_fetchPrediction_cmd_targetPc;
-  wire  IBusCachedPlugin_fetchPrediction_rsp_wasRight;
-  wire [31:0] IBusCachedPlugin_fetchPrediction_rsp_finalPc;
-  wire [31:0] IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord;
-  wire  IBusCachedPlugin_pcValids_0;
-  wire  IBusCachedPlugin_pcValids_1;
-  wire  IBusCachedPlugin_pcValids_2;
-  wire  IBusCachedPlugin_pcValids_3;
-  wire  IBusCachedPlugin_redoBranch_valid;
-  wire [31:0] IBusCachedPlugin_redoBranch_payload;
-  reg  IBusCachedPlugin_decodeExceptionPort_valid;
-  reg [3:0] IBusCachedPlugin_decodeExceptionPort_payload_code;
-  wire [31:0] IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire  IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire [31:0] IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire  IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
-  wire [31:0] IBusCachedPlugin_mmuBus_rsp_physicalAddress;
-  wire  IBusCachedPlugin_mmuBus_rsp_isIoAccess;
-  wire  IBusCachedPlugin_mmuBus_rsp_allowRead;
-  wire  IBusCachedPlugin_mmuBus_rsp_allowWrite;
-  wire  IBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire  IBusCachedPlugin_mmuBus_rsp_exception;
-  wire  IBusCachedPlugin_mmuBus_rsp_refilling;
-  wire  IBusCachedPlugin_mmuBus_end;
-  wire  IBusCachedPlugin_mmuBus_busy;
-  wire  DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire [31:0] DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire  DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
-  wire [31:0] DBusCachedPlugin_mmuBus_rsp_physicalAddress;
-  wire  DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-  wire  DBusCachedPlugin_mmuBus_rsp_allowRead;
-  wire  DBusCachedPlugin_mmuBus_rsp_allowWrite;
-  wire  DBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire  DBusCachedPlugin_mmuBus_rsp_exception;
-  wire  DBusCachedPlugin_mmuBus_rsp_refilling;
-  wire  DBusCachedPlugin_mmuBus_end;
-  wire  DBusCachedPlugin_mmuBus_busy;
-  reg  DBusCachedPlugin_redoBranch_valid;
-  wire [31:0] DBusCachedPlugin_redoBranch_payload;
-  reg  DBusCachedPlugin_exceptionBus_valid;
-  reg [3:0] DBusCachedPlugin_exceptionBus_payload_code;
-  wire [31:0] DBusCachedPlugin_exceptionBus_payload_badAddr;
-  wire  decodeExceptionPort_valid;
-  wire [3:0] decodeExceptionPort_payload_code;
-  wire [31:0] decodeExceptionPort_payload_badAddr;
-  wire  BranchPlugin_jumpInterface_valid;
-  wire [31:0] BranchPlugin_jumpInterface_payload;
-  reg  BranchPlugin_branchExceptionPort_valid;
-  wire [3:0] BranchPlugin_branchExceptionPort_payload_code;
-  wire [31:0] BranchPlugin_branchExceptionPort_payload_badAddr;
-  reg  CsrPlugin_jumpInterface_valid;
-  reg [31:0] CsrPlugin_jumpInterface_payload;
-  wire  CsrPlugin_exceptionPendings_0;
-  wire  CsrPlugin_exceptionPendings_1;
-  wire  CsrPlugin_exceptionPendings_2;
-  wire  CsrPlugin_exceptionPendings_3;
-  wire  externalInterrupt;
-  wire  contextSwitching;
-  reg [1:0] CsrPlugin_privilege;
-  wire  CsrPlugin_forceMachineWire;
-  wire  CsrPlugin_allowInterrupts;
-  wire  CsrPlugin_allowException;
-  wire  IBusCachedPlugin_jump_pcLoad_valid;
-  wire [31:0] IBusCachedPlugin_jump_pcLoad_payload;
-  wire [3:0] _zz_109_;
-  wire [3:0] _zz_110_;
-  wire  _zz_111_;
-  wire  _zz_112_;
-  wire  _zz_113_;
-  wire  IBusCachedPlugin_fetchPc_preOutput_valid;
-  wire  IBusCachedPlugin_fetchPc_preOutput_ready;
-  wire [31:0] IBusCachedPlugin_fetchPc_preOutput_payload;
-  wire  _zz_114_;
-  wire  IBusCachedPlugin_fetchPc_output_valid;
-  wire  IBusCachedPlugin_fetchPc_output_ready;
-  wire [31:0] IBusCachedPlugin_fetchPc_output_payload;
-  wire  IBusCachedPlugin_fetchPc_predictionPcLoad_valid;
-  wire [31:0] IBusCachedPlugin_fetchPc_predictionPcLoad_payload;
-  reg [31:0] IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
-  reg  IBusCachedPlugin_fetchPc_inc;
-  reg  IBusCachedPlugin_fetchPc_propagatePc;
-  reg [31:0] IBusCachedPlugin_fetchPc_pc;
-  reg  IBusCachedPlugin_fetchPc_samplePcNext;
-  reg  _zz_115_;
-  wire  IBusCachedPlugin_iBusRsp_stages_0_input_valid;
-  wire  IBusCachedPlugin_iBusRsp_stages_0_input_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  wire  IBusCachedPlugin_iBusRsp_stages_0_output_valid;
-  wire  IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_stages_0_output_payload;
-  reg  IBusCachedPlugin_iBusRsp_stages_0_halt;
-  wire  IBusCachedPlugin_iBusRsp_stages_0_inputSample;
-  wire  IBusCachedPlugin_iBusRsp_stages_1_input_valid;
-  wire  IBusCachedPlugin_iBusRsp_stages_1_input_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  wire  IBusCachedPlugin_iBusRsp_stages_1_output_valid;
-  wire  IBusCachedPlugin_iBusRsp_stages_1_output_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  reg  IBusCachedPlugin_iBusRsp_stages_1_halt;
-  wire  IBusCachedPlugin_iBusRsp_stages_1_inputSample;
-  wire  IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid;
-  wire  IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload;
-  wire  IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_valid;
-  wire  IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_payload;
-  reg  IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt;
-  wire  IBusCachedPlugin_iBusRsp_cacheRspArbitration_inputSample;
-  wire  _zz_116_;
-  wire  _zz_117_;
-  wire  _zz_118_;
-  wire  _zz_119_;
-  wire  _zz_120_;
-  reg  _zz_121_;
-  wire  _zz_122_;
-  reg  _zz_123_;
-  reg [31:0] _zz_124_;
-  reg  IBusCachedPlugin_iBusRsp_readyForError;
-  wire  IBusCachedPlugin_iBusRsp_decodeInput_valid;
-  wire  IBusCachedPlugin_iBusRsp_decodeInput_ready;
-  wire [31:0] IBusCachedPlugin_iBusRsp_decodeInput_payload_pc;
-  wire  IBusCachedPlugin_iBusRsp_decodeInput_payload_rsp_error;
-  wire [31:0] IBusCachedPlugin_iBusRsp_decodeInput_payload_rsp_inst;
-  wire  IBusCachedPlugin_iBusRsp_decodeInput_payload_isRvc;
-  reg  IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  reg  IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  reg  IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  reg  IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  reg  IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  reg  IBusCachedPlugin_injector_decodeRemoved;
-  reg  IBusCachedPlugin_predictor_historyWrite_valid;
-  wire [9:0] IBusCachedPlugin_predictor_historyWrite_payload_address;
-  wire [19:0] IBusCachedPlugin_predictor_historyWrite_payload_data_source;
-  reg [1:0] IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
-  wire [31:0] IBusCachedPlugin_predictor_historyWrite_payload_data_target;
-  wire [29:0] _zz_125_;
-  wire  _zz_126_;
-  wire [19:0] IBusCachedPlugin_predictor_line_source;
-  wire [1:0] IBusCachedPlugin_predictor_line_branchWish;
-  wire [31:0] IBusCachedPlugin_predictor_line_target;
-  wire [53:0] _zz_127_;
-  wire  IBusCachedPlugin_predictor_hit;
-  reg  IBusCachedPlugin_predictor_historyWriteLast_valid;
-  reg [9:0] IBusCachedPlugin_predictor_historyWriteLast_payload_address;
-  reg [19:0] IBusCachedPlugin_predictor_historyWriteLast_payload_data_source;
-  reg [1:0] IBusCachedPlugin_predictor_historyWriteLast_payload_data_branchWish;
-  reg [31:0] IBusCachedPlugin_predictor_historyWriteLast_payload_data_target;
-  wire  IBusCachedPlugin_predictor_hazard;
-  wire  IBusCachedPlugin_predictor_fetchContext_hazard;
-  wire  IBusCachedPlugin_predictor_fetchContext_hit;
-  wire [19:0] IBusCachedPlugin_predictor_fetchContext_line_source;
-  wire [1:0] IBusCachedPlugin_predictor_fetchContext_line_branchWish;
-  wire [31:0] IBusCachedPlugin_predictor_fetchContext_line_target;
-  reg  IBusCachedPlugin_predictor_fetchContext_regNextWhen_hazard;
-  reg  IBusCachedPlugin_predictor_fetchContext_regNextWhen_hit;
-  reg [19:0] IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_source;
-  reg [1:0] IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_branchWish;
-  reg [31:0] IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_target;
-  wire  IBusCachedPlugin_predictor_injectorContext_hazard;
-  wire  IBusCachedPlugin_predictor_injectorContext_hit;
-  wire [19:0] IBusCachedPlugin_predictor_injectorContext_line_source;
-  wire [1:0] IBusCachedPlugin_predictor_injectorContext_line_branchWish;
-  wire [31:0] IBusCachedPlugin_predictor_injectorContext_line_target;
-  wire  iBus_cmd_valid;
-  wire  iBus_cmd_ready;
-  reg [31:0] iBus_cmd_payload_address;
-  wire [2:0] iBus_cmd_payload_size;
-  wire  iBus_rsp_valid;
-  wire [31:0] iBus_rsp_payload_data;
-  wire  iBus_rsp_payload_error;
-  wire  IBusCachedPlugin_s0_tightlyCoupledHit;
-  reg  IBusCachedPlugin_s1_tightlyCoupledHit;
-  reg  IBusCachedPlugin_s2_tightlyCoupledHit;
-  wire  IBusCachedPlugin_rsp_iBusRspOutputHalt;
-  reg  IBusCachedPlugin_rsp_redoFetch;
-  wire  dBus_cmd_valid;
-  wire  dBus_cmd_ready;
-  wire  dBus_cmd_payload_wr;
-  wire [31:0] dBus_cmd_payload_address;
-  wire [31:0] dBus_cmd_payload_data;
-  wire [3:0] dBus_cmd_payload_mask;
-  wire [2:0] dBus_cmd_payload_length;
-  wire  dBus_cmd_payload_last;
-  wire  dBus_rsp_valid;
-  wire [31:0] dBus_rsp_payload_data;
-  wire  dBus_rsp_payload_error;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire [31:0] dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire [31:0] dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire [3:0] dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire [2:0] dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg  _zz_128_;
-  reg  _zz_129_;
-  reg [31:0] _zz_130_;
-  reg [31:0] _zz_131_;
-  reg [3:0] _zz_132_;
-  reg [2:0] _zz_133_;
-  reg  _zz_134_;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire [31:0] dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire [31:0] dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire [3:0] dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire [2:0] dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire  dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg  _zz_135_;
-  reg  _zz_136_;
-  reg [31:0] _zz_137_;
-  reg [31:0] _zz_138_;
-  reg [3:0] _zz_139_;
-  reg [2:0] _zz_140_;
-  reg  _zz_141_;
-  wire [1:0] execute_DBusCachedPlugin_size;
-  reg [31:0] _zz_142_;
-  reg [31:0] writeBack_DBusCachedPlugin_rspShifted;
-  wire  _zz_143_;
-  reg [31:0] _zz_144_;
-  wire  _zz_145_;
-  reg [31:0] _zz_146_;
-  reg [31:0] writeBack_DBusCachedPlugin_rspFormated;
-  wire [32:0] _zz_147_;
-  wire  _zz_148_;
-  wire  _zz_149_;
-  wire  _zz_150_;
-  wire  _zz_151_;
-  wire  _zz_152_;
-  wire  _zz_153_;
-  wire `AluBitwiseCtrlEnum_defaultEncoding_type _zz_154_;
-  wire `BranchCtrlEnum_defaultEncoding_type _zz_155_;
-  wire `Src1CtrlEnum_defaultEncoding_type _zz_156_;
-  wire `Src2CtrlEnum_defaultEncoding_type _zz_157_;
-  wire `EnvCtrlEnum_defaultEncoding_type _zz_158_;
-  wire `AluCtrlEnum_defaultEncoding_type _zz_159_;
-  wire `ShiftCtrlEnum_defaultEncoding_type _zz_160_;
-  wire [4:0] decode_RegFilePlugin_regFileReadAddress1;
-  wire [4:0] decode_RegFilePlugin_regFileReadAddress2;
-  wire [31:0] decode_RegFilePlugin_rs1Data;
-  wire [31:0] decode_RegFilePlugin_rs2Data;
-  reg  lastStageRegFileWrite_valid /* verilator public */ ;
-  wire [4:0] lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire [31:0] lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg  _zz_161_;
-  reg [31:0] execute_IntAluPlugin_bitwise;
-  reg [31:0] _zz_162_;
-  reg [31:0] _zz_163_;
-  wire  _zz_164_;
-  reg [19:0] _zz_165_;
-  wire  _zz_166_;
-  reg [19:0] _zz_167_;
-  reg [31:0] _zz_168_;
-  reg [31:0] execute_SrcPlugin_addSub;
-  wire  execute_SrcPlugin_less;
-  wire [4:0] execute_FullBarrelShifterPlugin_amplitude;
-  reg [31:0] _zz_169_;
-  wire [31:0] execute_FullBarrelShifterPlugin_reversed;
-  reg [31:0] _zz_170_;
-  reg  _zz_171_;
-  reg  _zz_172_;
-  wire  _zz_173_;
-  reg  _zz_174_;
-  reg [4:0] _zz_175_;
-  reg [31:0] _zz_176_;
-  wire  _zz_177_;
-  wire  _zz_178_;
-  wire  _zz_179_;
-  wire  _zz_180_;
-  wire  _zz_181_;
-  wire  _zz_182_;
-  wire  execute_BranchPlugin_eq;
-  wire [2:0] _zz_183_;
-  reg  _zz_184_;
-  reg  _zz_185_;
-  wire [31:0] execute_BranchPlugin_branch_src1;
-  wire  _zz_186_;
-  reg [10:0] _zz_187_;
-  wire  _zz_188_;
-  reg [19:0] _zz_189_;
-  wire  _zz_190_;
-  reg [18:0] _zz_191_;
-  reg [31:0] _zz_192_;
-  wire [31:0] execute_BranchPlugin_branch_src2;
-  wire [31:0] execute_BranchPlugin_branchAdder;
-  wire  execute_BranchPlugin_predictionMissmatch;
-  wire [1:0] CsrPlugin_misa_base;
-  wire [25:0] CsrPlugin_misa_extensions;
-  reg [1:0] CsrPlugin_mtvec_mode;
-  reg [29:0] CsrPlugin_mtvec_base;
-  reg [31:0] CsrPlugin_mepc;
-  reg  CsrPlugin_mstatus_MIE;
-  reg  CsrPlugin_mstatus_MPIE;
-  reg [1:0] CsrPlugin_mstatus_MPP;
-  reg  CsrPlugin_mip_MEIP;
-  reg  CsrPlugin_mip_MTIP;
-  reg  CsrPlugin_mip_MSIP;
-  reg  CsrPlugin_mie_MEIE;
-  reg  CsrPlugin_mie_MTIE;
-  reg  CsrPlugin_mie_MSIE;
-  reg  CsrPlugin_mcause_interrupt;
-  reg [3:0] CsrPlugin_mcause_exceptionCode;
-  reg [31:0] CsrPlugin_mtval;
-  reg [63:0] CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg [63:0] CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire  _zz_193_;
-  wire  _zz_194_;
-  wire  _zz_195_;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-  reg  CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  reg [3:0] CsrPlugin_exceptionPortCtrl_exceptionContext_code;
-  reg [31:0] CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
-  wire [1:0] CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
-  wire [1:0] CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire [1:0] _zz_196_;
-  wire  _zz_197_;
-  reg  CsrPlugin_interrupt_valid;
-  reg [3:0] CsrPlugin_interrupt_code /* verilator public */ ;
-  reg [1:0] CsrPlugin_interrupt_targetPrivilege;
-  wire  CsrPlugin_exception;
-  wire  CsrPlugin_lastStageWasWfi;
-  reg  CsrPlugin_pipelineLiberator_done;
-  wire  CsrPlugin_interruptJump /* verilator public */ ;
-  reg  CsrPlugin_hadException;
-  reg [1:0] CsrPlugin_targetPrivilege;
-  reg [3:0] CsrPlugin_trapCause;
-  reg [1:0] CsrPlugin_xtvec_mode;
-  reg [29:0] CsrPlugin_xtvec_base;
-  wire  execute_CsrPlugin_inWfi /* verilator public */ ;
-  reg  execute_CsrPlugin_wfiWake;
-  wire  execute_CsrPlugin_blockedBySideEffects;
-  reg  execute_CsrPlugin_illegalAccess;
-  reg  execute_CsrPlugin_illegalInstruction;
-  reg [31:0] execute_CsrPlugin_readData;
-  wire  execute_CsrPlugin_writeInstruction;
-  wire  execute_CsrPlugin_readInstruction;
-  wire  execute_CsrPlugin_writeEnable;
-  wire  execute_CsrPlugin_readEnable;
-  wire [31:0] execute_CsrPlugin_readToWriteData;
-  reg [31:0] execute_CsrPlugin_writeData;
-  wire [11:0] execute_CsrPlugin_csrAddress;
-  reg  execute_MulPlugin_aSigned;
-  reg  execute_MulPlugin_bSigned;
-  wire [31:0] execute_MulPlugin_a;
-  wire [31:0] execute_MulPlugin_b;
-  wire [15:0] execute_MulPlugin_aULow;
-  wire [15:0] execute_MulPlugin_bULow;
-  wire [16:0] execute_MulPlugin_aSLow;
-  wire [16:0] execute_MulPlugin_bSLow;
-  wire [16:0] execute_MulPlugin_aHigh;
-  wire [16:0] execute_MulPlugin_bHigh;
-  wire [65:0] writeBack_MulPlugin_result;
-  reg [32:0] memory_DivPlugin_rs1;
-  reg [31:0] memory_DivPlugin_rs2;
-  reg [64:0] memory_DivPlugin_accumulator;
-  reg  memory_DivPlugin_div_needRevert;
-  reg  memory_DivPlugin_div_counter_willIncrement;
-  reg  memory_DivPlugin_div_counter_willClear;
-  reg [5:0] memory_DivPlugin_div_counter_valueNext;
-  reg [5:0] memory_DivPlugin_div_counter_value;
-  wire  memory_DivPlugin_div_counter_willOverflowIfInc;
-  wire  memory_DivPlugin_div_counter_willOverflow;
-  reg  memory_DivPlugin_div_done;
-  reg [31:0] memory_DivPlugin_div_result;
-  wire [31:0] _zz_198_;
-  wire [32:0] _zz_199_;
-  wire [32:0] _zz_200_;
-  wire [31:0] _zz_201_;
-  wire  _zz_202_;
-  wire  _zz_203_;
-  reg [32:0] _zz_204_;
-  reg [31:0] externalInterruptArray_regNext;
-  reg [31:0] _zz_205_;
-  wire [31:0] _zz_206_;
-  reg `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg [31:0] decode_to_execute_RS1;
-  reg  decode_to_execute_SRC_LESS_UNSIGNED;
-  reg `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg  decode_to_execute_IS_RS2_SIGNED;
-  reg [31:0] execute_to_memory_REGFILE_WRITE_DATA;
-  reg [31:0] memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg  decode_to_execute_PREDICTION_CONTEXT_hazard;
-  reg  decode_to_execute_PREDICTION_CONTEXT_hit;
-  reg [19:0] decode_to_execute_PREDICTION_CONTEXT_line_source;
-  reg [1:0] decode_to_execute_PREDICTION_CONTEXT_line_branchWish;
-  reg [31:0] decode_to_execute_PREDICTION_CONTEXT_line_target;
-  reg [1:0] execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg [1:0] memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg  decode_to_execute_IS_CSR;
-  reg `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg [31:0] execute_to_memory_SHIFT_RIGHT;
-  reg  decode_to_execute_MEMORY_ENABLE;
-  reg  execute_to_memory_MEMORY_ENABLE;
-  reg  memory_to_writeBack_MEMORY_ENABLE;
-  reg  decode_to_execute_REGFILE_WRITE_VALID;
-  reg  execute_to_memory_REGFILE_WRITE_VALID;
-  reg  memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg [33:0] execute_to_memory_MUL_HH;
-  reg [33:0] memory_to_writeBack_MUL_HH;
-  reg  decode_to_execute_SRC_USE_SUB_LESS;
-  reg  decode_to_execute_MEMORY_WR;
-  reg  execute_to_memory_MEMORY_WR;
-  reg  memory_to_writeBack_MEMORY_WR;
-  reg  decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg [31:0] decode_to_execute_PC;
-  reg [31:0] execute_to_memory_PC;
-  reg [31:0] memory_to_writeBack_PC;
-  reg [31:0] decode_to_execute_RS2;
-  reg  decode_to_execute_IS_DIV;
-  reg  execute_to_memory_IS_DIV;
-  reg `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg  decode_to_execute_MEMORY_MANAGMENT;
-  reg  decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg  execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg [33:0] execute_to_memory_MUL_HL;
-  reg  decode_to_execute_MEMORY_AMO;
-  reg  decode_to_execute_CSR_READ_OPCODE;
-  reg [31:0] execute_to_memory_MUL_LL;
-  reg [33:0] execute_to_memory_MUL_LH;
-  reg  decode_to_execute_SRC2_FORCE_ZERO;
-  reg  decode_to_execute_CSR_WRITE_OPCODE;
-  reg  decode_to_execute_IS_RS1_SIGNED;
-  reg  decode_to_execute_MEMORY_LRSC;
-  reg [51:0] memory_to_writeBack_MUL_LOW;
-  reg `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg [31:0] decode_to_execute_INSTRUCTION;
-  reg [31:0] execute_to_memory_INSTRUCTION;
-  reg [31:0] memory_to_writeBack_INSTRUCTION;
-  reg `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg [31:0] decode_to_execute_FORMAL_PC_NEXT;
-  reg [31:0] execute_to_memory_FORMAL_PC_NEXT;
-  reg [31:0] memory_to_writeBack_FORMAL_PC_NEXT;
-  reg  decode_to_execute_IS_MUL;
-  reg  execute_to_memory_IS_MUL;
-  reg  memory_to_writeBack_IS_MUL;
-  reg [2:0] _zz_207_;
-  reg  _zz_208_;
-  reg [31:0] iBusWishbone_DAT_MISO_regNext;
-  reg [2:0] _zz_209_;
-  wire  _zz_210_;
-  wire  _zz_211_;
-  wire  _zz_212_;
-  wire  _zz_213_;
-  wire  _zz_214_;
-  reg  _zz_215_;
-  reg [31:0] dBusWishbone_DAT_MISO_regNext;
+  input      [31:0]   externalResetVector,
+  input               timerInterrupt,
+  input               softwareInterrupt,
+  input      [31:0]   externalInterruptArray,
+  output reg          iBusWishbone_CYC,
+  output reg          iBusWishbone_STB,
+  input               iBusWishbone_ACK,
+  output              iBusWishbone_WE,
+  output     [29:0]   iBusWishbone_ADR,
+  input      [31:0]   iBusWishbone_DAT_MISO,
+  output     [31:0]   iBusWishbone_DAT_MOSI,
+  output     [3:0]    iBusWishbone_SEL,
+  input               iBusWishbone_ERR,
+  output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
+  output              dBusWishbone_CYC,
+  output              dBusWishbone_STB,
+  input               dBusWishbone_ACK,
+  output              dBusWishbone_WE,
+  output     [29:0]   dBusWishbone_ADR,
+  input      [31:0]   dBusWishbone_DAT_MISO,
+  output     [31:0]   dBusWishbone_DAT_MOSI,
+  output     [3:0]    dBusWishbone_SEL,
+  input               dBusWishbone_ERR,
+  output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
+  input               clk,
+  input               reset
+);
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  reg                 dataCache_1_io_cpu_execute_args_isLrsc;
+  wire                dataCache_1_io_cpu_execute_args_amoCtrl_swap;
+  wire       [2:0]    dataCache_1_io_cpu_execute_args_amoCtrl_alu;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [53:0]   _zz_IBusCachedPlugin_predictor_history_port1;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
+  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
+  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_error;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
+  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_data;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_cacheMiss;
+  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_physicalAddress;
+  wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
+  wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
+  wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [14:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [8:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [2:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [2:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [53:0]   _zz_IBusCachedPlugin_predictor_history_port;
+  wire       [9:0]    _zz_IBusCachedPlugin_predictor_history_port_1;
+  wire       [9:0]    _zz__zz_IBusCachedPlugin_predictor_buffer_line_source_1;
+  wire       [9:0]    _zz_IBusCachedPlugin_predictor_buffer_hazard;
+  wire       [29:0]   _zz_IBusCachedPlugin_predictor_buffer_hazard_1;
+  wire       [19:0]   _zz_IBusCachedPlugin_predictor_hit;
+  wire       [1:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
+  wire       [1:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_1;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_2;
+  wire       [1:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_3;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_4;
+  wire       [1:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_6;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_7;
+  wire       [1:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_8;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_9;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspRf;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [25:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_167;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_168;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_169;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_170;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_171;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_172;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_173;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_174;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_175;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_176;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_177;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_178;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_179;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BRANCH_SRC22;
+  wire       [11:0]   _zz__zz_execute_BRANCH_SRC22_4;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
+  wire       [51:0]   memory_MUL_LOW;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_LRSC;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
+  wire                decode_PREDICTION_CONTEXT_hazard;
+  wire                decode_PREDICTION_CONTEXT_hit;
+  wire       [19:0]   decode_PREDICTION_CONTEXT_line_source;
+  wire       [1:0]    decode_PREDICTION_CONTEXT_line_branchWish;
+  wire       [31:0]   decode_PREDICTION_CONTEXT_line_target;
+  wire       [31:0]   writeBack_FORMAL_PC_NEXT;
+  wire       [31:0]   memory_FORMAL_PC_NEXT;
+  wire       [31:0]   execute_FORMAL_PC_NEXT;
+  wire       [31:0]   decode_FORMAL_PC_NEXT;
+  wire       [31:0]   memory_PC;
+  wire                execute_IS_RS1_SIGNED;
+  wire                execute_IS_DIV;
+  wire                execute_IS_RS2_SIGNED;
+  wire                memory_IS_DIV;
+  wire                writeBack_IS_MUL;
+  wire       [33:0]   writeBack_MUL_HH;
+  wire       [51:0]   writeBack_MUL_LOW;
+  wire       [33:0]   memory_MUL_HL;
+  wire       [33:0]   memory_MUL_LH;
+  wire       [31:0]   memory_MUL_LL;
+  wire                execute_CSR_READ_OPCODE;
+  wire                execute_CSR_WRITE_OPCODE;
+  wire                execute_IS_CSR;
+  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [31:0]   execute_NEXT_PC2;
+  wire                execute_TARGET_MISSMATCH2;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire       [31:0]   execute_BRANCH_SRC22;
+  wire       [31:0]   execute_PC;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
+  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire                decode_RS2_USE;
+  wire                decode_RS1_USE;
+  reg        [31:0]   _zz_decode_RS2;
+  wire                execute_REGFILE_WRITE_VALID;
+  wire                execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                memory_REGFILE_WRITE_VALID;
+  wire       [31:0]   memory_INSTRUCTION;
+  wire                memory_BYPASSABLE_MEMORY_STAGE;
+  wire                writeBack_REGFILE_WRITE_VALID;
+  reg        [31:0]   decode_RS2;
+  reg        [31:0]   decode_RS1;
+  wire       [31:0]   memory_SHIFT_RIGHT;
+  reg        [31:0]   _zz_decode_RS2_1;
+  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire                execute_SRC_LESS_UNSIGNED;
+  wire                execute_SRC2_FORCE_ZERO;
+  wire                execute_SRC_USE_SUB_LESS;
+  wire       [31:0]   _zz_execute_SRC2;
+  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
+  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire                decode_SRC_USE_SUB_LESS;
+  wire                decode_SRC_ADD_ZERO;
+  wire       [31:0]   execute_SRC_ADD_SUB;
+  wire                execute_SRC_LESS;
+  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
+  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [31:0]   execute_SRC2;
+  wire       [31:0]   execute_SRC1;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
+  wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
+  reg                 decode_REGFILE_WRITE_VALID;
+  wire                decode_LEGAL_INSTRUCTION;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
+  wire                writeBack_MEMORY_LRSC;
+  wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
+  wire                writeBack_MEMORY_ENABLE;
+  wire       [31:0]   memory_REGFILE_WRITE_DATA;
+  wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_AMO;
+  wire                execute_MEMORY_LRSC;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                execute_MEMORY_MANAGMENT;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
+  wire                execute_MEMORY_WR;
+  wire       [31:0]   execute_SRC_ADD;
+  wire                execute_MEMORY_ENABLE;
+  wire       [31:0]   execute_INSTRUCTION;
+  wire                decode_MEMORY_AMO;
+  wire                decode_MEMORY_LRSC;
+  reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
+  wire                decode_MEMORY_ENABLE;
+  wire                decode_FLUSH_ALL;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
+  wire       [31:0]   decode_INSTRUCTION;
+  wire                execute_PREDICTION_CONTEXT_hazard;
+  wire                execute_PREDICTION_CONTEXT_hit;
+  wire       [19:0]   execute_PREDICTION_CONTEXT_line_source;
+  wire       [1:0]    execute_PREDICTION_CONTEXT_line_branchWish;
+  wire       [31:0]   execute_PREDICTION_CONTEXT_line_target;
+  reg                 _zz_2;
+  reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
+  wire       [31:0]   decode_PC;
+  wire       [31:0]   writeBack_PC;
+  wire       [31:0]   writeBack_INSTRUCTION;
+  reg                 decode_arbitration_haltItself;
+  reg                 decode_arbitration_haltByOther;
+  reg                 decode_arbitration_removeIt;
+  wire                decode_arbitration_flushIt;
+  reg                 decode_arbitration_flushNext;
+  wire                decode_arbitration_isValid;
+  wire                decode_arbitration_isStuck;
+  wire                decode_arbitration_isStuckByOthers;
+  wire                decode_arbitration_isFlushed;
+  wire                decode_arbitration_isMoving;
+  wire                decode_arbitration_isFiring;
+  reg                 execute_arbitration_haltItself;
+  reg                 execute_arbitration_haltByOther;
+  reg                 execute_arbitration_removeIt;
+  wire                execute_arbitration_flushIt;
+  reg                 execute_arbitration_flushNext;
+  reg                 execute_arbitration_isValid;
+  wire                execute_arbitration_isStuck;
+  wire                execute_arbitration_isStuckByOthers;
+  wire                execute_arbitration_isFlushed;
+  wire                execute_arbitration_isMoving;
+  wire                execute_arbitration_isFiring;
+  reg                 memory_arbitration_haltItself;
+  wire                memory_arbitration_haltByOther;
+  reg                 memory_arbitration_removeIt;
+  wire                memory_arbitration_flushIt;
+  wire                memory_arbitration_flushNext;
+  reg                 memory_arbitration_isValid;
+  wire                memory_arbitration_isStuck;
+  wire                memory_arbitration_isStuckByOthers;
+  wire                memory_arbitration_isFlushed;
+  wire                memory_arbitration_isMoving;
+  wire                memory_arbitration_isFiring;
+  reg                 writeBack_arbitration_haltItself;
+  wire                writeBack_arbitration_haltByOther;
+  reg                 writeBack_arbitration_removeIt;
+  reg                 writeBack_arbitration_flushIt;
+  reg                 writeBack_arbitration_flushNext;
+  reg                 writeBack_arbitration_isValid;
+  wire                writeBack_arbitration_isStuck;
+  wire                writeBack_arbitration_isStuckByOthers;
+  wire                writeBack_arbitration_isFlushed;
+  wire                writeBack_arbitration_isMoving;
+  wire                writeBack_arbitration_isFiring;
+  wire       [31:0]   lastStageInstruction /* verilator public */ ;
+  wire       [31:0]   lastStagePc /* verilator public */ ;
+  wire                lastStageIsValid /* verilator public */ ;
+  wire                lastStageIsFiring /* verilator public */ ;
+  reg                 IBusCachedPlugin_fetcherHalt;
+  reg                 IBusCachedPlugin_incomingInstruction;
+  wire                IBusCachedPlugin_fetchPrediction_cmd_hadBranch;
+  wire       [31:0]   IBusCachedPlugin_fetchPrediction_cmd_targetPc;
+  wire                IBusCachedPlugin_fetchPrediction_rsp_wasRight;
+  wire       [31:0]   IBusCachedPlugin_fetchPrediction_rsp_finalPc;
+  wire       [31:0]   IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord;
+  wire                IBusCachedPlugin_pcValids_0;
+  wire                IBusCachedPlugin_pcValids_1;
+  wire                IBusCachedPlugin_pcValids_2;
+  wire                IBusCachedPlugin_pcValids_3;
+  reg                 IBusCachedPlugin_decodeExceptionPort_valid;
+  reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
+  wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
+  wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire                IBusCachedPlugin_mmuBus_rsp_exception;
+  wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_end;
+  wire                IBusCachedPlugin_mmuBus_busy;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_size;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
+  wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
+  wire                DBusCachedPlugin_mmuBus_rsp_allowRead;
+  wire                DBusCachedPlugin_mmuBus_rsp_allowWrite;
+  wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire                DBusCachedPlugin_mmuBus_rsp_exception;
+  wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                DBusCachedPlugin_mmuBus_end;
+  wire                DBusCachedPlugin_mmuBus_busy;
+  reg                 DBusCachedPlugin_redoBranch_valid;
+  wire       [31:0]   DBusCachedPlugin_redoBranch_payload;
+  reg                 DBusCachedPlugin_exceptionBus_valid;
+  reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
+  wire                decodeExceptionPort_valid;
+  wire       [3:0]    decodeExceptionPort_payload_code;
+  wire       [31:0]   decodeExceptionPort_payload_badAddr;
+  wire                BranchPlugin_jumpInterface_valid;
+  wire       [31:0]   BranchPlugin_jumpInterface_payload;
+  reg                 BranchPlugin_branchExceptionPort_valid;
+  wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
+  wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_inWfi /* verilator public */ ;
+  wire                CsrPlugin_thirdPartyWake;
+  reg                 CsrPlugin_jumpInterface_valid;
+  reg        [31:0]   CsrPlugin_jumpInterface_payload;
+  wire                CsrPlugin_exceptionPendings_0;
+  wire                CsrPlugin_exceptionPendings_1;
+  wire                CsrPlugin_exceptionPendings_2;
+  wire                CsrPlugin_exceptionPendings_3;
+  wire                externalInterrupt;
+  wire                contextSwitching;
+  reg        [1:0]    CsrPlugin_privilege;
+  wire                CsrPlugin_forceMachineWire;
+  wire                CsrPlugin_allowInterrupts;
+  wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
+  wire                IBusCachedPlugin_externalFlush;
+  wire                IBusCachedPlugin_jump_pcLoad_valid;
+  wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                IBusCachedPlugin_fetchPc_output_valid;
+  wire                IBusCachedPlugin_fetchPc_output_ready;
+  wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
+  reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
+  reg                 IBusCachedPlugin_fetchPc_correction;
+  reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                IBusCachedPlugin_fetchPc_output_fire;
+  wire                IBusCachedPlugin_fetchPc_corrected;
+  wire                IBusCachedPlugin_fetchPc_pcRegPropagate;
+  reg                 IBusCachedPlugin_fetchPc_booted;
+  reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                IBusCachedPlugin_fetchPc_output_fire_1;
+  wire                when_Fetcher_l131_1;
+  reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
+  wire                IBusCachedPlugin_fetchPc_predictionPcLoad_valid;
+  wire       [31:0]   IBusCachedPlugin_fetchPc_predictionPcLoad_payload;
+  wire                IBusCachedPlugin_fetchPc_redo_valid;
+  wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
+  reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
+  reg                 IBusCachedPlugin_iBusRsp_redoFetch;
+  wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_0_input_payload;
+  wire                IBusCachedPlugin_iBusRsp_stages_0_output_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_0_output_payload;
+  reg                 IBusCachedPlugin_iBusRsp_stages_0_halt;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  reg                 IBusCachedPlugin_iBusRsp_stages_1_halt;
+  wire                IBusCachedPlugin_iBusRsp_stages_2_input_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_input_payload;
+  wire                IBusCachedPlugin_iBusRsp_stages_2_output_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
+  reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  wire                IBusCachedPlugin_iBusRsp_flush;
+  wire                IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_payload;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 IBusCachedPlugin_iBusRsp_readyForError;
+  wire                IBusCachedPlugin_iBusRsp_output_valid;
+  wire                IBusCachedPlugin_iBusRsp_output_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_pc;
+  wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
+  wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
+  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
+  wire                when_Fetcher_l329_4;
+  wire                IBusCachedPlugin_predictor_historyWriteDelayPatched_valid;
+  wire       [9:0]    IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_address;
+  wire       [19:0]   IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_source;
+  wire       [1:0]    IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_branchWish;
+  wire       [31:0]   IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_target;
+  reg                 IBusCachedPlugin_predictor_historyWrite_valid;
+  wire       [9:0]    IBusCachedPlugin_predictor_historyWrite_payload_address;
+  wire       [19:0]   IBusCachedPlugin_predictor_historyWrite_payload_data_source;
+  reg        [1:0]    IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
+  wire       [31:0]   IBusCachedPlugin_predictor_historyWrite_payload_data_target;
+  reg                 IBusCachedPlugin_predictor_writeLast_valid;
+  reg        [9:0]    IBusCachedPlugin_predictor_writeLast_payload_address;
+  reg        [19:0]   IBusCachedPlugin_predictor_writeLast_payload_data_source;
+  reg        [1:0]    IBusCachedPlugin_predictor_writeLast_payload_data_branchWish;
+  reg        [31:0]   IBusCachedPlugin_predictor_writeLast_payload_data_target;
+  wire       [29:0]   _zz_IBusCachedPlugin_predictor_buffer_line_source;
+  wire       [19:0]   IBusCachedPlugin_predictor_buffer_line_source;
+  wire       [1:0]    IBusCachedPlugin_predictor_buffer_line_branchWish;
+  wire       [31:0]   IBusCachedPlugin_predictor_buffer_line_target;
+  wire       [53:0]   _zz_IBusCachedPlugin_predictor_buffer_line_source_1;
+  reg                 IBusCachedPlugin_predictor_buffer_pcCorrected;
+  wire                IBusCachedPlugin_predictor_buffer_hazard;
+  reg        [19:0]   IBusCachedPlugin_predictor_line_source;
+  reg        [1:0]    IBusCachedPlugin_predictor_line_branchWish;
+  reg        [31:0]   IBusCachedPlugin_predictor_line_target;
+  reg                 IBusCachedPlugin_predictor_buffer_hazard_regNextWhen;
+  wire                IBusCachedPlugin_predictor_hazard;
+  wire                IBusCachedPlugin_predictor_hit;
+  wire                IBusCachedPlugin_predictor_fetchContext_hazard;
+  wire                IBusCachedPlugin_predictor_fetchContext_hit;
+  wire       [19:0]   IBusCachedPlugin_predictor_fetchContext_line_source;
+  wire       [1:0]    IBusCachedPlugin_predictor_fetchContext_line_branchWish;
+  wire       [31:0]   IBusCachedPlugin_predictor_fetchContext_line_target;
+  reg                 IBusCachedPlugin_predictor_iBusRspContext_hazard;
+  reg                 IBusCachedPlugin_predictor_iBusRspContext_hit;
+  reg        [19:0]   IBusCachedPlugin_predictor_iBusRspContext_line_source;
+  reg        [1:0]    IBusCachedPlugin_predictor_iBusRspContext_line_branchWish;
+  reg        [31:0]   IBusCachedPlugin_predictor_iBusRspContext_line_target;
+  wire                IBusCachedPlugin_predictor_iBusRspContextOutput_hazard;
+  wire                IBusCachedPlugin_predictor_iBusRspContextOutput_hit;
+  wire       [19:0]   IBusCachedPlugin_predictor_iBusRspContextOutput_line_source;
+  wire       [1:0]    IBusCachedPlugin_predictor_iBusRspContextOutput_line_branchWish;
+  wire       [31:0]   IBusCachedPlugin_predictor_iBusRspContextOutput_line_target;
+  wire                IBusCachedPlugin_predictor_injectorContext_hazard;
+  wire                IBusCachedPlugin_predictor_injectorContext_hit;
+  wire       [19:0]   IBusCachedPlugin_predictor_injectorContext_line_source;
+  wire       [1:0]    IBusCachedPlugin_predictor_injectorContext_line_branchWish;
+  wire       [31:0]   IBusCachedPlugin_predictor_injectorContext_line_target;
+  wire                when_Fetcher_l596;
+  wire                iBus_cmd_valid;
+  wire                iBus_cmd_ready;
+  reg        [31:0]   iBus_cmd_payload_address;
+  wire       [2:0]    iBus_cmd_payload_size;
+  wire                iBus_rsp_valid;
+  wire       [31:0]   iBus_rsp_payload_data;
+  wire                iBus_rsp_payload_error;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
+  reg        [31:0]   IBusCachedPlugin_rspCounter;
+  wire                IBusCachedPlugin_s0_tightlyCoupledHit;
+  reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
+  reg                 IBusCachedPlugin_s2_tightlyCoupledHit;
+  wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
+  wire                IBusCachedPlugin_rsp_issueDetected;
+  reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_rValid;
+  reg                 dataCache_1_io_mem_cmd_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
+  reg                 dataCache_1_io_mem_cmd_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l342;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l311;
+  wire       [1:0]    execute_DBusCachedPlugin_size;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire                when_DBusCachedPlugin_l474;
+  wire       [1:0]    switch_Misc_l200;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz_decode_IS_RS2_SIGNED_6;
+  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
+  wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
+  wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
+  wire       [31:0]   decode_RegFilePlugin_rs1Data;
+  wire       [31:0]   decode_RegFilePlugin_rs2Data;
+  reg                 lastStageRegFileWrite_valid /* verilator public */ ;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_3;
+  reg        [31:0]   execute_IntAluPlugin_bitwise;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
+  reg        [31:0]   execute_SrcPlugin_addSub;
+  wire                execute_SrcPlugin_less;
+  wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
+  wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
+  wire                execute_BranchPlugin_eq;
+  wire       [2:0]    switch_Misc_l200_1;
+  reg                 _zz_execute_BRANCH_DO;
+  reg                 _zz_execute_BRANCH_DO_1;
+  wire       [31:0]   execute_BranchPlugin_branch_src1;
+  wire                _zz_execute_BRANCH_SRC22;
+  reg        [10:0]   _zz_execute_BRANCH_SRC22_1;
+  wire                _zz_execute_BRANCH_SRC22_2;
+  reg        [19:0]   _zz_execute_BRANCH_SRC22_3;
+  wire                _zz_execute_BRANCH_SRC22_4;
+  reg        [18:0]   _zz_execute_BRANCH_SRC22_5;
+  reg        [31:0]   _zz_execute_BRANCH_SRC22_6;
+  wire       [31:0]   execute_BranchPlugin_branchAdder;
+  wire                execute_BranchPlugin_predictionMissmatch;
+  wire                when_BranchPlugin_l375;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
+  reg        [1:0]    CsrPlugin_mtvec_mode;
+  reg        [29:0]   CsrPlugin_mtvec_base;
+  reg        [31:0]   CsrPlugin_mepc;
+  reg                 CsrPlugin_mstatus_MIE;
+  reg                 CsrPlugin_mstatus_MPIE;
+  reg        [1:0]    CsrPlugin_mstatus_MPP;
+  reg                 CsrPlugin_mip_MEIP;
+  reg                 CsrPlugin_mip_MTIP;
+  reg                 CsrPlugin_mip_MSIP;
+  reg                 CsrPlugin_mie_MEIE;
+  reg                 CsrPlugin_mie_MTIE;
+  reg                 CsrPlugin_mie_MSIE;
+  reg                 CsrPlugin_mcause_interrupt;
+  reg        [3:0]    CsrPlugin_mcause_exceptionCode;
+  reg        [31:0]   CsrPlugin_mtval;
+  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
+  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+  wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
+  wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
+  reg                 CsrPlugin_interrupt_valid;
+  reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
+  reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
+  wire                CsrPlugin_exception;
+  wire                CsrPlugin_lastStageWasWfi;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_0;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_1;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_2;
+  wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
+  reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
+  wire                CsrPlugin_interruptJump /* verilator public */ ;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
+  reg        [1:0]    CsrPlugin_targetPrivilege;
+  reg        [3:0]    CsrPlugin_trapCause;
+  reg        [1:0]    CsrPlugin_xtvec_mode;
+  reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
+  reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
+  wire                execute_CsrPlugin_blockedBySideEffects;
+  reg                 execute_CsrPlugin_illegalAccess;
+  reg                 execute_CsrPlugin_illegalInstruction;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  reg                 execute_CsrPlugin_writeInstruction;
+  reg                 execute_CsrPlugin_readInstruction;
+  wire                execute_CsrPlugin_writeEnable;
+  wire                execute_CsrPlugin_readEnable;
+  wire       [31:0]   execute_CsrPlugin_readToWriteData;
+  wire                switch_Misc_l200_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
+  wire       [11:0]   execute_CsrPlugin_csrAddress;
+  reg                 execute_MulPlugin_aSigned;
+  reg                 execute_MulPlugin_bSigned;
+  wire       [31:0]   execute_MulPlugin_a;
+  wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
+  wire       [15:0]   execute_MulPlugin_aULow;
+  wire       [15:0]   execute_MulPlugin_bULow;
+  wire       [16:0]   execute_MulPlugin_aSLow;
+  wire       [16:0]   execute_MulPlugin_bSLow;
+  wire       [16:0]   execute_MulPlugin_aHigh;
+  wire       [16:0]   execute_MulPlugin_bHigh;
+  wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
+  reg        [32:0]   memory_DivPlugin_rs1;
+  reg        [31:0]   memory_DivPlugin_rs2;
+  reg        [64:0]   memory_DivPlugin_accumulator;
+  wire                memory_DivPlugin_frontendOk;
+  reg                 memory_DivPlugin_div_needRevert;
+  reg                 memory_DivPlugin_div_counter_willIncrement;
+  reg                 memory_DivPlugin_div_counter_willClear;
+  reg        [5:0]    memory_DivPlugin_div_counter_valueNext;
+  reg        [5:0]    memory_DivPlugin_div_counter_value;
+  wire                memory_DivPlugin_div_counter_willOverflowIfInc;
+  wire                memory_DivPlugin_div_counter_willOverflow;
+  reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
+  reg        [31:0]   memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
+  wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
+  wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
+  reg        [31:0]   externalInterruptArray_regNext;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
+  reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
+  reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
+  reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
+  reg                 decode_to_execute_PREDICTION_CONTEXT_hazard;
+  reg                 decode_to_execute_PREDICTION_CONTEXT_hit;
+  reg        [19:0]   decode_to_execute_PREDICTION_CONTEXT_line_source;
+  reg        [1:0]    decode_to_execute_PREDICTION_CONTEXT_line_branchWish;
+  reg        [31:0]   decode_to_execute_PREDICTION_CONTEXT_line_target;
+  wire                when_Pipeline_l124_10;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_11;
+  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_12;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_13;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_16;
+  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_17;
+  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_18;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_21;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_22;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_24;
+  reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
+  reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_27;
+  reg                 decode_to_execute_MEMORY_LRSC;
+  wire                when_Pipeline_l124_28;
+  reg                 execute_to_memory_MEMORY_LRSC;
+  wire                when_Pipeline_l124_29;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
+  wire                when_Pipeline_l124_30;
+  reg                 decode_to_execute_MEMORY_AMO;
+  wire                when_Pipeline_l124_31;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_32;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_33;
+  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_34;
+  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_35;
+  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_36;
+  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_37;
+  reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_38;
+  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_39;
+  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_40;
+  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_41;
+  reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_42;
+  reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_43;
+  reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_44;
+  reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_45;
+  reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_46;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_47;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_48;
+  reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_49;
+  reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_50;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_51;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_52;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_53;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_54;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_55;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_56;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_57;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_58;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_59;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_60;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_61;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_62;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_63;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
+  reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
+  reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_2;
+  reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_3;
+  reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_4;
+  reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_5;
+  reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_6;
+  reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_7;
+  reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_8;
+  reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_9;
+  reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
+  reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  reg                 _zz_dBus_rsp_valid;
+  reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_1__string;
-  reg [39:0] _zz_2__string;
-  reg [39:0] _zz_3__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_4__string;
-  reg [95:0] _zz_5__string;
-  reg [95:0] _zz_6__string;
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_7__string;
-  reg [23:0] _zz_8__string;
-  reg [23:0] _zz_9__string;
-  reg [31:0] _zz_10__string;
-  reg [31:0] _zz_11__string;
-  reg [31:0] _zz_12__string;
-  reg [31:0] _zz_13__string;
+  reg [31:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [31:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [31:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [31:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [31:0] decode_ENV_CTRL_string;
-  reg [31:0] _zz_14__string;
-  reg [31:0] _zz_15__string;
-  reg [31:0] _zz_16__string;
+  reg [31:0] _zz_decode_ENV_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_ENV_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_17__string;
-  reg [31:0] _zz_18__string;
-  reg [31:0] _zz_19__string;
-  reg [71:0] _zz_20__string;
-  reg [71:0] _zz_21__string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [71:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [71:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_22__string;
-  reg [71:0] _zz_23__string;
-  reg [71:0] _zz_24__string;
+  reg [71:0] _zz_decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_25__string;
-  reg [63:0] _zz_26__string;
-  reg [63:0] _zz_27__string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [31:0] memory_ENV_CTRL_string;
-  reg [31:0] _zz_33__string;
+  reg [31:0] _zz_memory_ENV_CTRL_string;
   reg [31:0] execute_ENV_CTRL_string;
-  reg [31:0] _zz_34__string;
+  reg [31:0] _zz_execute_ENV_CTRL_string;
   reg [31:0] writeBack_ENV_CTRL_string;
-  reg [31:0] _zz_37__string;
+  reg [31:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_41__string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_45__string;
+  reg [71:0] _zz_memory_SHIFT_CTRL_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_47__string;
+  reg [71:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_52__string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_54__string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_57__string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_59__string;
-  reg [71:0] _zz_67__string;
-  reg [63:0] _zz_70__string;
-  reg [31:0] _zz_74__string;
-  reg [23:0] _zz_78__string;
-  reg [95:0] _zz_79__string;
-  reg [31:0] _zz_84__string;
-  reg [39:0] _zz_88__string;
-  reg [39:0] _zz_154__string;
-  reg [31:0] _zz_155__string;
-  reg [95:0] _zz_156__string;
-  reg [23:0] _zz_157__string;
-  reg [31:0] _zz_158__string;
-  reg [63:0] _zz_159__string;
-  reg [71:0] _zz_160__string;
+  reg [39:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [31:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [71:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [39:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [39:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [31:0] _zz_decode_ENV_CTRL_2_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [31:0] decode_to_execute_ENV_CTRL_string;
   reg [31:0] execute_to_memory_ENV_CTRL_string;
   reg [31:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [53:0] IBusCachedPlugin_predictor_history [0:1023];
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
-  assign _zz_243_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_244_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_245_ = 1'b1;
-  assign _zz_246_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_247_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_248_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_249_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_94_));
-  assign _zz_250_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_95_));
-  assign _zz_251_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_96_));
-  assign _zz_252_ = ((_zz_222_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! 1'b0));
-  assign _zz_253_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_254_ = (! memory_DivPlugin_div_done);
-  assign _zz_255_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_256_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_257_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_258_ = (IBusCachedPlugin_fetchPc_preOutput_valid && IBusCachedPlugin_fetchPc_preOutput_ready);
-  assign _zz_259_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_260_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_261_ = (1'b0 || (! 1'b1));
-  assign _zz_262_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_263_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_264_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_265_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_266_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_267_ = (! memory_arbitration_isStuck);
-  assign _zz_268_ = (iBus_cmd_valid || (_zz_207_ != (3'b000)));
-  assign _zz_269_ = (_zz_238_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_270_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_271_ = ((_zz_193_ && 1'b1) && (! 1'b0));
-  assign _zz_272_ = ((_zz_194_ && 1'b1) && (! 1'b0));
-  assign _zz_273_ = ((_zz_195_ && 1'b1) && (! 1'b0));
-  assign _zz_274_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_275_ = execute_INSTRUCTION[13];
-  assign _zz_276_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_277_ = (_zz_109_ - (4'b0001));
-  assign _zz_278_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_279_ = {29'd0, _zz_278_};
-  assign _zz_280_ = _zz_125_[9:0];
-  assign _zz_281_ = (IBusCachedPlugin_iBusRsp_stages_1_input_payload >>> 12);
-  assign _zz_282_ = (IBusCachedPlugin_iBusRsp_stages_1_input_payload >>> 2);
-  assign _zz_283_ = _zz_282_[9:0];
-  assign _zz_284_ = (execute_PREDICTION_CONTEXT_line_branchWish + _zz_286_);
-  assign _zz_285_ = (execute_PREDICTION_CONTEXT_line_branchWish == (2'b10));
-  assign _zz_286_ = {1'd0, _zz_285_};
-  assign _zz_287_ = (execute_PREDICTION_CONTEXT_line_branchWish == (2'b01));
-  assign _zz_288_ = {1'd0, _zz_287_};
-  assign _zz_289_ = (execute_PREDICTION_CONTEXT_line_branchWish - _zz_291_);
-  assign _zz_290_ = execute_PREDICTION_CONTEXT_line_branchWish[1];
-  assign _zz_291_ = {1'd0, _zz_290_};
-  assign _zz_292_ = (! execute_PREDICTION_CONTEXT_line_branchWish[1]);
-  assign _zz_293_ = {1'd0, _zz_292_};
-  assign _zz_294_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_295_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_296_ = _zz_147_[0 : 0];
-  assign _zz_297_ = _zz_147_[1 : 1];
-  assign _zz_298_ = _zz_147_[4 : 4];
-  assign _zz_299_ = _zz_147_[5 : 5];
-  assign _zz_300_ = _zz_147_[6 : 6];
-  assign _zz_301_ = _zz_147_[9 : 9];
-  assign _zz_302_ = _zz_147_[10 : 10];
-  assign _zz_303_ = _zz_147_[11 : 11];
-  assign _zz_304_ = _zz_147_[12 : 12];
-  assign _zz_305_ = _zz_147_[17 : 17];
-  assign _zz_306_ = _zz_147_[18 : 18];
-  assign _zz_307_ = _zz_147_[19 : 19];
-  assign _zz_308_ = _zz_147_[21 : 21];
-  assign _zz_309_ = _zz_147_[22 : 22];
-  assign _zz_310_ = _zz_147_[23 : 23];
-  assign _zz_311_ = _zz_147_[26 : 26];
-  assign _zz_312_ = _zz_147_[27 : 27];
-  assign _zz_313_ = _zz_147_[31 : 31];
-  assign _zz_314_ = _zz_147_[32 : 32];
-  assign _zz_315_ = execute_SRC_LESS;
-  assign _zz_316_ = (3'b100);
-  assign _zz_317_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_318_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_319_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_320_ = ($signed(_zz_321_) + $signed(_zz_324_));
-  assign _zz_321_ = ($signed(_zz_322_) + $signed(_zz_323_));
-  assign _zz_322_ = execute_SRC1;
-  assign _zz_323_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_324_ = (execute_SRC_USE_SUB_LESS ? _zz_325_ : _zz_326_);
-  assign _zz_325_ = (32'b00000000000000000000000000000001);
-  assign _zz_326_ = (32'b00000000000000000000000000000000);
-  assign _zz_327_ = ($signed(_zz_329_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_328_ = _zz_327_[31 : 0];
-  assign _zz_329_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_330_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_331_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_332_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_333_ = (_zz_196_ & (~ _zz_334_));
-  assign _zz_334_ = (_zz_196_ - (2'b01));
-  assign _zz_335_ = ($signed(_zz_336_) + $signed(_zz_341_));
-  assign _zz_336_ = ($signed(_zz_337_) + $signed(_zz_339_));
-  assign _zz_337_ = (52'b0000000000000000000000000000000000000000000000000000);
-  assign _zz_338_ = {1'b0,memory_MUL_LL};
-  assign _zz_339_ = {{19{_zz_338_[32]}}, _zz_338_};
-  assign _zz_340_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_341_ = {{2{_zz_340_[49]}}, _zz_340_};
-  assign _zz_342_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_343_ = {{2{_zz_342_[49]}}, _zz_342_};
-  assign _zz_344_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_345_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_346_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_347_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_348_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_349_ = {5'd0, _zz_348_};
-  assign _zz_350_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_351_ = {_zz_198_,(! _zz_200_[32])};
-  assign _zz_352_ = _zz_200_[31:0];
-  assign _zz_353_ = _zz_199_[31:0];
-  assign _zz_354_ = _zz_355_;
-  assign _zz_355_ = _zz_356_;
-  assign _zz_356_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_201_) : _zz_201_)} + _zz_358_);
-  assign _zz_357_ = memory_DivPlugin_div_needRevert;
-  assign _zz_358_ = {32'd0, _zz_357_};
-  assign _zz_359_ = _zz_203_;
-  assign _zz_360_ = {32'd0, _zz_359_};
-  assign _zz_361_ = _zz_202_;
-  assign _zz_362_ = {31'd0, _zz_361_};
-  assign _zz_363_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_364_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_365_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_366_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_367_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_368_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_369_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_370_ = {IBusCachedPlugin_predictor_historyWrite_payload_data_target,{IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish,IBusCachedPlugin_predictor_historyWrite_payload_data_source}};
-  assign _zz_371_ = 1'b1;
-  assign _zz_372_ = 1'b1;
-  assign _zz_373_ = {_zz_113_,_zz_112_};
-  assign _zz_374_ = (32'b00010000000000000000000000001000);
-  assign _zz_375_ = (_zz_384_ == _zz_385_);
-  assign _zz_376_ = {_zz_386_,{_zz_387_,_zz_388_}};
-  assign _zz_377_ = (_zz_389_ == _zz_390_);
-  assign _zz_378_ = {_zz_391_,{_zz_392_,_zz_393_}};
-  assign _zz_379_ = {_zz_394_,_zz_395_};
-  assign _zz_380_ = (2'b00);
-  assign _zz_381_ = ({_zz_396_,_zz_397_} != (3'b000));
-  assign _zz_382_ = (_zz_398_ != _zz_399_);
-  assign _zz_383_ = {_zz_400_,{_zz_401_,_zz_402_}};
-  assign _zz_384_ = (decode_INSTRUCTION & (32'b00000000000000000001000000010000));
-  assign _zz_385_ = (32'b00000000000000000001000000010000);
-  assign _zz_386_ = ((decode_INSTRUCTION & _zz_403_) == (32'b00000000000000000010000000010000));
-  assign _zz_387_ = (_zz_404_ == _zz_405_);
-  assign _zz_388_ = {_zz_406_,{_zz_407_,_zz_408_}};
-  assign _zz_389_ = (decode_INSTRUCTION & (32'b00000000000000000000000001010000));
-  assign _zz_390_ = (32'b00000000000000000000000001000000);
-  assign _zz_391_ = ((decode_INSTRUCTION & _zz_409_) == (32'b00000000000000000000000001000000));
-  assign _zz_392_ = (_zz_410_ == _zz_411_);
-  assign _zz_393_ = (_zz_412_ == _zz_413_);
-  assign _zz_394_ = ((decode_INSTRUCTION & _zz_414_) == (32'b00000000000000000101000000010000));
-  assign _zz_395_ = ((decode_INSTRUCTION & _zz_415_) == (32'b00000000000000000101000000100000));
-  assign _zz_396_ = (_zz_416_ == _zz_417_);
-  assign _zz_397_ = {_zz_418_,_zz_419_};
-  assign _zz_398_ = {_zz_420_,_zz_421_};
-  assign _zz_399_ = (2'b00);
-  assign _zz_400_ = (_zz_149_ != (1'b0));
-  assign _zz_401_ = (_zz_422_ != _zz_423_);
-  assign _zz_402_ = {_zz_424_,{_zz_425_,_zz_426_}};
-  assign _zz_403_ = (32'b00000000000000000010000000010000);
-  assign _zz_404_ = (decode_INSTRUCTION & (32'b00000000000000000010000000001000));
-  assign _zz_405_ = (32'b00000000000000000010000000001000);
-  assign _zz_406_ = ((decode_INSTRUCTION & _zz_427_) == (32'b00000000000000000000000000010000));
-  assign _zz_407_ = _zz_153_;
-  assign _zz_408_ = (_zz_428_ == _zz_429_);
-  assign _zz_409_ = (32'b00000000000000000011000001000000);
-  assign _zz_410_ = (decode_INSTRUCTION & (32'b00000000000000000000000000111000));
-  assign _zz_411_ = (32'b00000000000000000000000000000000);
-  assign _zz_412_ = (decode_INSTRUCTION & (32'b00011000000000000010000000001000));
-  assign _zz_413_ = (32'b00010000000000000010000000001000);
-  assign _zz_414_ = (32'b00000000000000000111000000110100);
-  assign _zz_415_ = (32'b00000010000000000111000001100100);
-  assign _zz_416_ = (decode_INSTRUCTION & (32'b01000000000000000011000001010100));
-  assign _zz_417_ = (32'b01000000000000000001000000010000);
-  assign _zz_418_ = ((decode_INSTRUCTION & _zz_430_) == (32'b00000000000000000001000000010000));
-  assign _zz_419_ = ((decode_INSTRUCTION & _zz_431_) == (32'b00000000000000000001000000010000));
-  assign _zz_420_ = ((decode_INSTRUCTION & _zz_432_) == (32'b00000000000000000010000000000000));
-  assign _zz_421_ = ((decode_INSTRUCTION & _zz_433_) == (32'b00000000000000000001000000000000));
-  assign _zz_422_ = (_zz_434_ == _zz_435_);
-  assign _zz_423_ = (1'b0);
-  assign _zz_424_ = (_zz_436_ != (1'b0));
-  assign _zz_425_ = (_zz_437_ != _zz_438_);
-  assign _zz_426_ = {_zz_439_,{_zz_440_,_zz_441_}};
-  assign _zz_427_ = (32'b00000000000000000000000001010000);
-  assign _zz_428_ = (decode_INSTRUCTION & (32'b00000000000000000000000000101000));
-  assign _zz_429_ = (32'b00000000000000000000000000000000);
-  assign _zz_430_ = (32'b00000000000000000111000000110100);
-  assign _zz_431_ = (32'b00000010000000000111000001010100);
-  assign _zz_432_ = (32'b00000000000000000010000000010000);
-  assign _zz_433_ = (32'b00000000000000000101000000000000);
-  assign _zz_434_ = (decode_INSTRUCTION & (32'b00000000000000000100000000010100));
-  assign _zz_435_ = (32'b00000000000000000100000000010000);
-  assign _zz_436_ = ((decode_INSTRUCTION & (32'b00000000000000000110000000010100)) == (32'b00000000000000000010000000010000));
-  assign _zz_437_ = ((decode_INSTRUCTION & (32'b00000010000000000100000001110100)) == (32'b00000010000000000000000000110000));
-  assign _zz_438_ = (1'b0);
-  assign _zz_439_ = ({_zz_153_,{_zz_442_,{_zz_443_,_zz_444_}}} != (5'b00000));
-  assign _zz_440_ = ({_zz_445_,{_zz_446_,_zz_447_}} != (5'b00000));
-  assign _zz_441_ = {(_zz_448_ != (1'b0)),{(_zz_449_ != _zz_450_),{_zz_451_,{_zz_452_,_zz_453_}}}};
-  assign _zz_442_ = ((decode_INSTRUCTION & _zz_454_) == (32'b00000000000000000010000000010000));
-  assign _zz_443_ = (_zz_455_ == _zz_456_);
-  assign _zz_444_ = {_zz_457_,_zz_458_};
-  assign _zz_445_ = ((decode_INSTRUCTION & _zz_459_) == (32'b00000000000000000000000001000000));
-  assign _zz_446_ = (_zz_460_ == _zz_461_);
-  assign _zz_447_ = {_zz_462_,{_zz_463_,_zz_464_}};
-  assign _zz_448_ = ((decode_INSTRUCTION & _zz_465_) == (32'b00000000000000000000000001010000));
-  assign _zz_449_ = (_zz_466_ == _zz_467_);
-  assign _zz_450_ = (1'b0);
-  assign _zz_451_ = ({_zz_468_,_zz_469_} != (3'b000));
-  assign _zz_452_ = (_zz_470_ != _zz_471_);
-  assign _zz_453_ = {_zz_472_,{_zz_473_,_zz_474_}};
-  assign _zz_454_ = (32'b00000000000000000010000000110000);
-  assign _zz_455_ = (decode_INSTRUCTION & (32'b00000000000000000001000000110000));
-  assign _zz_456_ = (32'b00000000000000000000000000010000);
-  assign _zz_457_ = ((decode_INSTRUCTION & _zz_475_) == (32'b00000000000000000000000000100000));
-  assign _zz_458_ = ((decode_INSTRUCTION & _zz_476_) == (32'b00000000000000000010000000100000));
-  assign _zz_459_ = (32'b00000000000000000000000001000000);
-  assign _zz_460_ = (decode_INSTRUCTION & (32'b00000000000000000100000000100000));
-  assign _zz_461_ = (32'b00000000000000000100000000100000);
-  assign _zz_462_ = ((decode_INSTRUCTION & _zz_477_) == (32'b00000000000000000000000000010000));
-  assign _zz_463_ = _zz_153_;
-  assign _zz_464_ = (_zz_478_ == _zz_479_);
-  assign _zz_465_ = (32'b00000000000000000011000001010000);
-  assign _zz_466_ = (decode_INSTRUCTION & (32'b00010000000000000000000000001000));
-  assign _zz_467_ = (32'b00010000000000000000000000001000);
-  assign _zz_468_ = (_zz_480_ == _zz_481_);
-  assign _zz_469_ = {_zz_482_,_zz_483_};
-  assign _zz_470_ = {_zz_484_,{_zz_485_,_zz_486_}};
-  assign _zz_471_ = (3'b000);
-  assign _zz_472_ = ({_zz_487_,_zz_488_} != (2'b00));
-  assign _zz_473_ = (_zz_489_ != _zz_490_);
-  assign _zz_474_ = {_zz_491_,{_zz_492_,_zz_493_}};
-  assign _zz_475_ = (32'b00000010000000000011000000100000);
-  assign _zz_476_ = (32'b00000010000000000010000001101000);
-  assign _zz_477_ = (32'b00000000000000000000000000110000);
-  assign _zz_478_ = (decode_INSTRUCTION & (32'b00000010000000000000000000101000));
-  assign _zz_479_ = (32'b00000000000000000000000000100000);
-  assign _zz_480_ = (decode_INSTRUCTION & (32'b00000000000000000000000001000100));
-  assign _zz_481_ = (32'b00000000000000000000000001000000);
-  assign _zz_482_ = ((decode_INSTRUCTION & _zz_494_) == (32'b00000000000000000010000000010000));
-  assign _zz_483_ = ((decode_INSTRUCTION & _zz_495_) == (32'b01000000000000000000000000110000));
-  assign _zz_484_ = ((decode_INSTRUCTION & _zz_496_) == (32'b00001000000000000000000000100000));
-  assign _zz_485_ = (_zz_497_ == _zz_498_);
-  assign _zz_486_ = (_zz_499_ == _zz_500_);
-  assign _zz_487_ = _zz_152_;
-  assign _zz_488_ = (_zz_501_ == _zz_502_);
-  assign _zz_489_ = {_zz_152_,_zz_503_};
-  assign _zz_490_ = (2'b00);
-  assign _zz_491_ = ({_zz_504_,_zz_505_} != (3'b000));
-  assign _zz_492_ = (_zz_506_ != _zz_507_);
-  assign _zz_493_ = {_zz_508_,{_zz_509_,_zz_510_}};
-  assign _zz_494_ = (32'b00000000000000000010000000010100);
-  assign _zz_495_ = (32'b01000000000000000000000000110100);
-  assign _zz_496_ = (32'b00001000000000000000000000100000);
-  assign _zz_497_ = (decode_INSTRUCTION & (32'b00010000000000000000000000100000));
-  assign _zz_498_ = (32'b00000000000000000000000000100000);
-  assign _zz_499_ = (decode_INSTRUCTION & (32'b00000000000000000000000000101000));
-  assign _zz_500_ = (32'b00000000000000000000000000100000);
-  assign _zz_501_ = (decode_INSTRUCTION & (32'b00000000000000000000000001110000));
-  assign _zz_502_ = (32'b00000000000000000000000000100000);
-  assign _zz_503_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000100000)) == (32'b00000000000000000000000000000000));
-  assign _zz_504_ = _zz_150_;
-  assign _zz_505_ = {_zz_151_,(_zz_511_ == _zz_512_)};
-  assign _zz_506_ = {_zz_151_,(_zz_513_ == _zz_514_)};
-  assign _zz_507_ = (2'b00);
-  assign _zz_508_ = ((_zz_515_ == _zz_516_) != (1'b0));
-  assign _zz_509_ = (_zz_517_ != (1'b0));
-  assign _zz_510_ = {(_zz_518_ != _zz_519_),{_zz_520_,{_zz_521_,_zz_522_}}};
-  assign _zz_511_ = (decode_INSTRUCTION & (32'b00000000000000000010000000010100));
-  assign _zz_512_ = (32'b00000000000000000000000000000100);
-  assign _zz_513_ = (decode_INSTRUCTION & (32'b00000000000000000000000001001100));
-  assign _zz_514_ = (32'b00000000000000000000000000000100);
-  assign _zz_515_ = (decode_INSTRUCTION & (32'b00000000000000000000000001100100));
-  assign _zz_516_ = (32'b00000000000000000000000000100100);
-  assign _zz_517_ = ((decode_INSTRUCTION & (32'b00000010000000000100000001100100)) == (32'b00000010000000000100000000100000));
-  assign _zz_518_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001001000)) == (32'b00000000000000000100000000001000));
-  assign _zz_519_ = (1'b0);
-  assign _zz_520_ = (((decode_INSTRUCTION & _zz_523_) == (32'b00000000000000000001000000001000)) != (1'b0));
-  assign _zz_521_ = ({_zz_150_,_zz_524_} != (2'b00));
-  assign _zz_522_ = {(_zz_525_ != (1'b0)),{(_zz_526_ != _zz_527_),{_zz_528_,{_zz_529_,_zz_530_}}}};
-  assign _zz_523_ = (32'b00000000000000000101000001001000);
-  assign _zz_524_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000011100)) == (32'b00000000000000000000000000000100));
-  assign _zz_525_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001011000)) == (32'b00000000000000000000000001000000));
-  assign _zz_526_ = {(_zz_531_ == _zz_532_),{_zz_533_,{_zz_534_,_zz_535_}}};
-  assign _zz_527_ = (5'b00000);
-  assign _zz_528_ = (_zz_149_ != (1'b0));
-  assign _zz_529_ = ({_zz_536_,_zz_537_} != (2'b00));
-  assign _zz_530_ = {(_zz_538_ != _zz_539_),{_zz_540_,{_zz_541_,_zz_542_}}};
-  assign _zz_531_ = (decode_INSTRUCTION & (32'b00000000000000000000000001000100));
-  assign _zz_532_ = (32'b00000000000000000000000000000000);
-  assign _zz_533_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000011000)) == (32'b00000000000000000000000000000000));
-  assign _zz_534_ = ((decode_INSTRUCTION & _zz_543_) == (32'b00000000000000000010000000000000));
-  assign _zz_535_ = {(_zz_544_ == _zz_545_),_zz_148_};
-  assign _zz_536_ = _zz_148_;
-  assign _zz_537_ = ((decode_INSTRUCTION & _zz_546_) == (32'b00000000000000000000000000000000));
-  assign _zz_538_ = ((decode_INSTRUCTION & _zz_547_) == (32'b00000000000000000001000000000000));
-  assign _zz_539_ = (1'b0);
-  assign _zz_540_ = ((_zz_548_ == _zz_549_) != (1'b0));
-  assign _zz_541_ = ({_zz_550_,_zz_551_} != (4'b0000));
-  assign _zz_542_ = ({_zz_552_,_zz_553_} != (2'b00));
-  assign _zz_543_ = (32'b00000000000000000110000000000100);
-  assign _zz_544_ = (decode_INSTRUCTION & (32'b00000000000000000101000000000100));
-  assign _zz_545_ = (32'b00000000000000000001000000000000);
-  assign _zz_546_ = (32'b00000000000000000000000001011000);
-  assign _zz_547_ = (32'b00000000000000000001000000000000);
-  assign _zz_548_ = (decode_INSTRUCTION & (32'b00000000000000000011000000000000));
-  assign _zz_549_ = (32'b00000000000000000010000000000000);
-  assign _zz_550_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000110100)) == (32'b00000000000000000000000000100000));
-  assign _zz_551_ = {((decode_INSTRUCTION & (32'b00000000000000000000000001100100)) == (32'b00000000000000000000000000100000)),{((decode_INSTRUCTION & (32'b00001000000000000000000001110000)) == (32'b00001000000000000000000000100000)),((decode_INSTRUCTION & (32'b00010000000000000000000001110000)) == (32'b00000000000000000000000000100000))}};
-  assign _zz_552_ = ((decode_INSTRUCTION & (32'b00000000000000000001000001010000)) == (32'b00000000000000000001000001010000));
-  assign _zz_553_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001010000)) == (32'b00000000000000000010000001010000));
-  assign _zz_554_ = (32'b00000000000000000001000001111111);
-  assign _zz_555_ = (decode_INSTRUCTION & (32'b00000000000000000010000001111111));
-  assign _zz_556_ = (32'b00000000000000000010000001110011);
-  assign _zz_557_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001111111)) == (32'b00000000000000000100000001100011));
-  assign _zz_558_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001111111)) == (32'b00000000000000000010000000010011));
-  assign _zz_559_ = {((decode_INSTRUCTION & (32'b00000000000000000110000000111111)) == (32'b00000000000000000000000000100011)),{((decode_INSTRUCTION & (32'b00000000000000000010000001111111)) == (32'b00000000000000000000000000000011)),{((decode_INSTRUCTION & _zz_560_) == (32'b00000000000000000000000000000011)),{(_zz_561_ == _zz_562_),{_zz_563_,{_zz_564_,_zz_565_}}}}}};
-  assign _zz_560_ = (32'b00000000000000000101000001011111);
-  assign _zz_561_ = (decode_INSTRUCTION & (32'b00000000000000000111000001111011));
-  assign _zz_562_ = (32'b00000000000000000000000001100011);
-  assign _zz_563_ = ((decode_INSTRUCTION & (32'b00000000000000000110000001111111)) == (32'b00000000000000000000000000001111));
-  assign _zz_564_ = ((decode_INSTRUCTION & (32'b00011000000000000111000001111111)) == (32'b00000000000000000010000000101111));
-  assign _zz_565_ = {((decode_INSTRUCTION & (32'b11111100000000000000000001111111)) == (32'b00000000000000000000000000110011)),{((decode_INSTRUCTION & (32'b11101000000000000111000001111111)) == (32'b00001000000000000010000000101111)),{((decode_INSTRUCTION & _zz_566_) == (32'b00000000000000000101000000001111)),{(_zz_567_ == _zz_568_),{_zz_569_,{_zz_570_,_zz_571_}}}}}};
-  assign _zz_566_ = (32'b00000001111100000111000001111111);
-  assign _zz_567_ = (decode_INSTRUCTION & (32'b10111100000000000111000001111111));
-  assign _zz_568_ = (32'b00000000000000000101000000010011);
-  assign _zz_569_ = ((decode_INSTRUCTION & (32'b11111100000000000011000001111111)) == (32'b00000000000000000001000000010011));
-  assign _zz_570_ = ((decode_INSTRUCTION & (32'b10111110000000000111000001111111)) == (32'b00000000000000000101000000110011));
-  assign _zz_571_ = {((decode_INSTRUCTION & (32'b10111110000000000111000001111111)) == (32'b00000000000000000000000000110011)),{((decode_INSTRUCTION & (32'b11111001111100000111000001111111)) == (32'b00010000000000000010000000101111)),((decode_INSTRUCTION & (32'b11011111111111111111111111111111)) == (32'b00010000001000000000000001110011))}};
-  always @ (posedge clk) begin
-    if(_zz_103_) begin
-      IBusCachedPlugin_predictor_history[IBusCachedPlugin_predictor_historyWrite_payload_address] <= _zz_370_;
+
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 3'b001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_predictor_buffer_line_source_1 = _zz_IBusCachedPlugin_predictor_buffer_line_source[9:0];
+  assign _zz_IBusCachedPlugin_predictor_buffer_hazard_1 = (IBusCachedPlugin_iBusRsp_stages_1_input_payload >>> 2);
+  assign _zz_IBusCachedPlugin_predictor_buffer_hazard = _zz_IBusCachedPlugin_predictor_buffer_hazard_1[9:0];
+  assign _zz_IBusCachedPlugin_predictor_hit = (IBusCachedPlugin_iBusRsp_stages_1_input_payload >>> 12);
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (execute_PREDICTION_CONTEXT_line_branchWish + _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_1);
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_2 = (execute_PREDICTION_CONTEXT_line_branchWish == 2'b10);
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_1 = {1'd0, _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_2};
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_4 = (execute_PREDICTION_CONTEXT_line_branchWish == 2'b01);
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_3 = {1'd0, _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_4};
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_5 = (execute_PREDICTION_CONTEXT_line_branchWish - _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_6);
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_7 = execute_PREDICTION_CONTEXT_line_branchWish[1];
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_6 = {1'd0, _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_7};
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_9 = (! execute_PREDICTION_CONTEXT_line_branchWish[1]);
+  assign _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_8 = {1'd0, _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_9};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BRANCH_SRC22 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BRANCH_SRC22_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_IBusCachedPlugin_predictor_history_port = {IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_target,{IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_branchWish,IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_source}};
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,_zz_IBusCachedPlugin_jump_pcLoad_payload_2};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073)}};
+  assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00003050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = ({(_zz__zz_decode_IS_RS2_SIGNED_6 == _zz__zz_decode_IS_RS2_SIGNED_7),(_zz__zz_decode_IS_RS2_SIGNED_8 == _zz__zz_decode_IS_RS2_SIGNED_9)} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = ({_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_11} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = {(_zz__zz_decode_IS_RS2_SIGNED_13 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_19),{_zz__zz_decode_IS_RS2_SIGNED_20,{_zz__zz_decode_IS_RS2_SIGNED_26,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = 32'h00001050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = 32'h00002050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = {(_zz__zz_decode_IS_RS2_SIGNED_15 == _zz__zz_decode_IS_RS2_SIGNED_16),(_zz__zz_decode_IS_RS2_SIGNED_17 == _zz__zz_decode_IS_RS2_SIGNED_18)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,{_zz__zz_decode_IS_RS2_SIGNED_22,_zz__zz_decode_IS_RS2_SIGNED_24}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (_zz__zz_decode_IS_RS2_SIGNED_27 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = 32'h00005020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_23) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ({_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_34} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (_zz__zz_decode_IS_RS2_SIGNED_36 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(_zz__zz_decode_IS_RS2_SIGNED_38 != _zz__zz_decode_IS_RS2_SIGNED_40),{_zz__zz_decode_IS_RS2_SIGNED_41,{_zz__zz_decode_IS_RS2_SIGNED_50,_zz__zz_decode_IS_RS2_SIGNED_52}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00007034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00003000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ({_zz__zz_decode_IS_RS2_SIGNED_42,{_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45}} != 4'b0000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = (_zz__zz_decode_IS_RS2_SIGNED_51 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = {(_zz__zz_decode_IS_RS2_SIGNED_53 != _zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_67,_zz__zz_decode_IS_RS2_SIGNED_76}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47),(_zz__zz_decode_IS_RS2_SIGNED_48 == _zz__zz_decode_IS_RS2_SIGNED_49)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ({_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_62}} != 4'b0000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = ({_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_71} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = {(_zz__zz_decode_IS_RS2_SIGNED_77 != _zz__zz_decode_IS_RS2_SIGNED_90),{_zz__zz_decode_IS_RS2_SIGNED_91,{_zz__zz_decode_IS_RS2_SIGNED_104,_zz__zz_decode_IS_RS2_SIGNED_123}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = (decode_INSTRUCTION & 32'h10000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (_zz__zz_decode_IS_RS2_SIGNED_60 == _zz__zz_decode_IS_RS2_SIGNED_61);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {_zz__zz_decode_IS_RS2_SIGNED_63,_zz__zz_decode_IS_RS2_SIGNED_65};
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = {_zz__zz_decode_IS_RS2_SIGNED_72,_zz__zz_decode_IS_RS2_SIGNED_74};
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = {_zz__zz_decode_IS_RS2_SIGNED_78,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_83}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ({_zz__zz_decode_IS_RS2_SIGNED_92,_zz__zz_decode_IS_RS2_SIGNED_93} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (_zz__zz_decode_IS_RS2_SIGNED_105 != _zz__zz_decode_IS_RS2_SIGNED_122);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {_zz__zz_decode_IS_RS2_SIGNED_124,{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_134}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (decode_INSTRUCTION & 32'h00003040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_64) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_66) == 32'h10002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_75) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (_zz__zz_decode_IS_RS2_SIGNED_81 == _zz__zz_decode_IS_RS2_SIGNED_82);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {_zz__zz_decode_IS_RS2_SIGNED_84,{_zz__zz_decode_IS_RS2_SIGNED_86,_zz__zz_decode_IS_RS2_SIGNED_87}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,{_zz__zz_decode_IS_RS2_SIGNED_96,_zz__zz_decode_IS_RS2_SIGNED_99}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_109}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 7'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ({_zz__zz_decode_IS_RS2_SIGNED_125,_zz__zz_decode_IS_RS2_SIGNED_126} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (_zz__zz_decode_IS_RS2_SIGNED_130 != _zz__zz_decode_IS_RS2_SIGNED_133);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = {_zz__zz_decode_IS_RS2_SIGNED_135,{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_143}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000038;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h18002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h10000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_85) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (_zz__zz_decode_IS_RS2_SIGNED_88 == _zz__zz_decode_IS_RS2_SIGNED_89);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_95) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (_zz__zz_decode_IS_RS2_SIGNED_97 == _zz__zz_decode_IS_RS2_SIGNED_98);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {_zz__zz_decode_IS_RS2_SIGNED_100,_zz__zz_decode_IS_RS2_SIGNED_102};
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (_zz__zz_decode_IS_RS2_SIGNED_107 == _zz__zz_decode_IS_RS2_SIGNED_108);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz__zz_decode_IS_RS2_SIGNED_110,{_zz__zz_decode_IS_RS2_SIGNED_112,_zz__zz_decode_IS_RS2_SIGNED_115}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (_zz__zz_decode_IS_RS2_SIGNED_127 == _zz__zz_decode_IS_RS2_SIGNED_128);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = {_zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_131};
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (_zz__zz_decode_IS_RS2_SIGNED_136 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = (_zz__zz_decode_IS_RS2_SIGNED_139 != _zz__zz_decode_IS_RS2_SIGNED_142);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = {_zz__zz_decode_IS_RS2_SIGNED_144,{_zz__zz_decode_IS_RS2_SIGNED_156,_zz__zz_decode_IS_RS2_SIGNED_161}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (decode_INSTRUCTION & 32'h02000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_101) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_103) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_111) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = {_zz__zz_decode_IS_RS2_SIGNED_116,{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_119}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_132) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_137) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = (_zz__zz_decode_IS_RS2_SIGNED_140 == _zz__zz_decode_IS_RS2_SIGNED_141);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = ({_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_148} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (_zz__zz_decode_IS_RS2_SIGNED_157 != _zz__zz_decode_IS_RS2_SIGNED_160);
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = {_zz__zz_decode_IS_RS2_SIGNED_162,{_zz__zz_decode_IS_RS2_SIGNED_169,_zz__zz_decode_IS_RS2_SIGNED_174}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = 32'h02002068;
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (_zz__zz_decode_IS_RS2_SIGNED_146 == _zz__zz_decode_IS_RS2_SIGNED_147);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = {_zz__zz_decode_IS_RS2_SIGNED_149,{_zz__zz_decode_IS_RS2_SIGNED_151,_zz__zz_decode_IS_RS2_SIGNED_154}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_158};
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = ({_zz__zz_decode_IS_RS2_SIGNED_163,_zz__zz_decode_IS_RS2_SIGNED_166} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_169 = (_zz__zz_decode_IS_RS2_SIGNED_170 != _zz__zz_decode_IS_RS2_SIGNED_173);
+  assign _zz__zz_decode_IS_RS2_SIGNED_174 = {_zz__zz_decode_IS_RS2_SIGNED_175,_zz__zz_decode_IS_RS2_SIGNED_178};
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_150) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (_zz__zz_decode_IS_RS2_SIGNED_152 == _zz__zz_decode_IS_RS2_SIGNED_153);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = {_zz__zz_decode_IS_RS2_SIGNED_155,_zz_decode_IS_RS2_SIGNED_3};
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_159) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (_zz__zz_decode_IS_RS2_SIGNED_164 == _zz__zz_decode_IS_RS2_SIGNED_165);
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = {_zz__zz_decode_IS_RS2_SIGNED_167,_zz__zz_decode_IS_RS2_SIGNED_168};
+  assign _zz__zz_decode_IS_RS2_SIGNED_170 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_171,_zz__zz_decode_IS_RS2_SIGNED_172}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_173 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_175 = ({_zz__zz_decode_IS_RS2_SIGNED_176,_zz__zz_decode_IS_RS2_SIGNED_177} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_178 = (_zz__zz_decode_IS_RS2_SIGNED_179 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = 32'h00000018;
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_167 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_168 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_171 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_172 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_176 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_177 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_179 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  always @(posedge clk) begin
+    if(_zz_2) begin
+      IBusCachedPlugin_predictor_history[IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_address] <= _zz_IBusCachedPlugin_predictor_history_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_126_) begin
-      _zz_239_ <= IBusCachedPlugin_predictor_history[_zz_280_];
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+      _zz_IBusCachedPlugin_predictor_history_port1 <= IBusCachedPlugin_predictor_history[_zz__zz_IBusCachedPlugin_predictor_buffer_line_source_1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_62_) begin
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_371_) begin
-      _zz_240_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_372_) begin
-      _zz_241_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
-    end
-  end
-
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush(_zz_216_),
-    .io_cpu_prefetch_isValid(_zz_217_),
-    .io_cpu_prefetch_haltIt(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt),
-    .io_cpu_prefetch_pc(IBusCachedPlugin_iBusRsp_stages_0_input_payload),
-    .io_cpu_fetch_isValid(_zz_218_),
-    .io_cpu_fetch_isStuck(_zz_219_),
-    .io_cpu_fetch_isRemoved(_zz_220_),
-    .io_cpu_fetch_pc(IBusCachedPlugin_iBusRsp_stages_1_input_payload),
-    .io_cpu_fetch_data(IBusCachedPlugin_cache_io_cpu_fetch_data),
-    .io_cpu_fetch_dataBypassValid(IBusCachedPlugin_s1_tightlyCoupledHit),
-    .io_cpu_fetch_dataBypass(_zz_221_),
-    .io_cpu_fetch_mmuBus_cmd_isValid(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid),
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress),
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation),
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress(IBusCachedPlugin_mmuBus_rsp_physicalAddress),
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess(IBusCachedPlugin_mmuBus_rsp_isIoAccess),
-    .io_cpu_fetch_mmuBus_rsp_allowRead(IBusCachedPlugin_mmuBus_rsp_allowRead),
-    .io_cpu_fetch_mmuBus_rsp_allowWrite(IBusCachedPlugin_mmuBus_rsp_allowWrite),
-    .io_cpu_fetch_mmuBus_rsp_allowExecute(IBusCachedPlugin_mmuBus_rsp_allowExecute),
-    .io_cpu_fetch_mmuBus_rsp_exception(IBusCachedPlugin_mmuBus_rsp_exception),
-    .io_cpu_fetch_mmuBus_rsp_refilling(IBusCachedPlugin_mmuBus_rsp_refilling),
-    .io_cpu_fetch_mmuBus_end(IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end),
-    .io_cpu_fetch_mmuBus_busy(IBusCachedPlugin_mmuBus_busy),
-    .io_cpu_fetch_physicalAddress(IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress),
-    .io_cpu_fetch_haltIt(IBusCachedPlugin_cache_io_cpu_fetch_haltIt),
-    .io_cpu_decode_isValid(_zz_222_),
-    .io_cpu_decode_isStuck(_zz_223_),
-    .io_cpu_decode_pc(IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload),
-    .io_cpu_decode_physicalAddress(IBusCachedPlugin_cache_io_cpu_decode_physicalAddress),
-    .io_cpu_decode_data(IBusCachedPlugin_cache_io_cpu_decode_data),
-    .io_cpu_decode_cacheMiss(IBusCachedPlugin_cache_io_cpu_decode_cacheMiss),
-    .io_cpu_decode_error(IBusCachedPlugin_cache_io_cpu_decode_error),
-    .io_cpu_decode_mmuRefilling(IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling),
-    .io_cpu_decode_mmuException(IBusCachedPlugin_cache_io_cpu_decode_mmuException),
-    .io_cpu_decode_isUser(_zz_224_),
-    .io_cpu_fill_valid(_zz_225_),
-    .io_cpu_fill_payload(IBusCachedPlugin_cache_io_cpu_decode_physicalAddress),
-    .io_mem_cmd_valid(IBusCachedPlugin_cache_io_mem_cmd_valid),
-    .io_mem_cmd_ready(iBus_cmd_ready),
-    .io_mem_cmd_payload_address(IBusCachedPlugin_cache_io_mem_cmd_payload_address),
-    .io_mem_cmd_payload_size(IBusCachedPlugin_cache_io_mem_cmd_payload_size),
-    .io_mem_rsp_valid(iBus_rsp_valid),
-    .io_mem_rsp_payload_data(iBus_rsp_payload_data),
-    .io_mem_rsp_payload_error(iBus_rsp_payload_error),
-    .clk(clk),
-    .reset(reset) 
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid(_zz_226_),
-    .io_cpu_execute_address(_zz_227_),
-    .io_cpu_execute_args_wr(execute_MEMORY_WR),
-    .io_cpu_execute_args_data(_zz_142_),
-    .io_cpu_execute_args_size(execute_DBusCachedPlugin_size),
-    .io_cpu_execute_args_isLrsc(_zz_228_),
-    .io_cpu_execute_args_isAmo(execute_MEMORY_AMO),
-    .io_cpu_execute_args_amoCtrl_swap(_zz_229_),
-    .io_cpu_execute_args_amoCtrl_alu(_zz_230_),
-    .io_cpu_memory_isValid(_zz_231_),
-    .io_cpu_memory_isStuck(memory_arbitration_isStuck),
-    .io_cpu_memory_isRemoved(memory_arbitration_removeIt),
-    .io_cpu_memory_isWrite(dataCache_1__io_cpu_memory_isWrite),
-    .io_cpu_memory_address(_zz_232_),
-    .io_cpu_memory_mmuBus_cmd_isValid(dataCache_1__io_cpu_memory_mmuBus_cmd_isValid),
-    .io_cpu_memory_mmuBus_cmd_virtualAddress(dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress),
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation(dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation),
-    .io_cpu_memory_mmuBus_rsp_physicalAddress(DBusCachedPlugin_mmuBus_rsp_physicalAddress),
-    .io_cpu_memory_mmuBus_rsp_isIoAccess(_zz_233_),
-    .io_cpu_memory_mmuBus_rsp_allowRead(DBusCachedPlugin_mmuBus_rsp_allowRead),
-    .io_cpu_memory_mmuBus_rsp_allowWrite(DBusCachedPlugin_mmuBus_rsp_allowWrite),
-    .io_cpu_memory_mmuBus_rsp_allowExecute(DBusCachedPlugin_mmuBus_rsp_allowExecute),
-    .io_cpu_memory_mmuBus_rsp_exception(DBusCachedPlugin_mmuBus_rsp_exception),
-    .io_cpu_memory_mmuBus_rsp_refilling(DBusCachedPlugin_mmuBus_rsp_refilling),
-    .io_cpu_memory_mmuBus_end(dataCache_1__io_cpu_memory_mmuBus_end),
-    .io_cpu_memory_mmuBus_busy(DBusCachedPlugin_mmuBus_busy),
-    .io_cpu_writeBack_isValid(_zz_234_),
-    .io_cpu_writeBack_isStuck(writeBack_arbitration_isStuck),
-    .io_cpu_writeBack_isUser(_zz_235_),
-    .io_cpu_writeBack_haltIt(dataCache_1__io_cpu_writeBack_haltIt),
-    .io_cpu_writeBack_isWrite(dataCache_1__io_cpu_writeBack_isWrite),
-    .io_cpu_writeBack_data(dataCache_1__io_cpu_writeBack_data),
-    .io_cpu_writeBack_address(_zz_236_),
-    .io_cpu_writeBack_mmuException(dataCache_1__io_cpu_writeBack_mmuException),
-    .io_cpu_writeBack_unalignedAccess(dataCache_1__io_cpu_writeBack_unalignedAccess),
-    .io_cpu_writeBack_accessError(dataCache_1__io_cpu_writeBack_accessError),
-    .io_cpu_writeBack_clearLrsc(contextSwitching),
-    .io_cpu_redo(dataCache_1__io_cpu_redo),
-    .io_cpu_flush_valid(_zz_237_),
-    .io_cpu_flush_ready(dataCache_1__io_cpu_flush_ready),
-    .io_mem_cmd_valid(dataCache_1__io_mem_cmd_valid),
-    .io_mem_cmd_ready(_zz_238_),
-    .io_mem_cmd_payload_wr(dataCache_1__io_mem_cmd_payload_wr),
-    .io_mem_cmd_payload_address(dataCache_1__io_mem_cmd_payload_address),
-    .io_mem_cmd_payload_data(dataCache_1__io_mem_cmd_payload_data),
-    .io_mem_cmd_payload_mask(dataCache_1__io_mem_cmd_payload_mask),
-    .io_mem_cmd_payload_length(dataCache_1__io_mem_cmd_payload_length),
-    .io_mem_cmd_payload_last(dataCache_1__io_mem_cmd_payload_last),
-    .io_mem_rsp_valid(dBus_rsp_valid),
-    .io_mem_rsp_payload_data(dBus_rsp_payload_data),
-    .io_mem_rsp_payload_error(dBus_rsp_payload_error),
-    .clk(clk),
-    .reset(reset) 
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_isLrsc                (dataCache_1_io_cpu_execute_args_isLrsc         ), //i
+    .io_cpu_execute_args_isAmo                 (execute_MEMORY_AMO                             ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (dataCache_1_io_cpu_execute_args_amoCtrl_swap   ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (dataCache_1_io_cpu_execute_args_amoCtrl_alu    ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_373_)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_5)
       2'b00 : begin
-        _zz_242_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_242_ = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_242_ = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = CsrPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_242_ = IBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = BranchPlugin_jumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_1__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_1__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_1__string = "AND_1";
-      default : _zz_1__string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_2__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_2__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_2__string = "AND_1";
-      default : _zz_2__string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_3__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_3__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_3__string = "AND_1";
-      default : _zz_3__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_4__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_4__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_4__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_4__string = "URS1        ";
-      default : _zz_4__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_5__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_5__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_5__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_5__string = "URS1        ";
-      default : _zz_5__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_6__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_6__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_6__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_6__string = "URS1        ";
-      default : _zz_6__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_7__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_7__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_7__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_7__string = "PC ";
-      default : _zz_7__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_8__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_8__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_8__string = "PC ";
-      default : _zz_8__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_9__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_9__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_9__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_9__string = "PC ";
-      default : _zz_9__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET";
-      default : _zz_10__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_11__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_11__string = "XRET";
-      default : _zz_11__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_12__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_12__string = "XRET";
-      default : _zz_12__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_13__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_13__string = "XRET";
-      default : _zz_13__string = "????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET";
       default : decode_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_14_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_14__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_14__string = "XRET";
-      default : _zz_14__string = "????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET";
+      default : _zz_decode_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_15_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_15__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_15__string = "XRET";
-      default : _zz_15__string = "????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_16_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_16__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_16__string = "XRET";
-      default : _zz_16__string = "????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
+      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_17_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_17__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_17__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_17__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_17__string = "JALR";
-      default : _zz_17__string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_18_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_18__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_18__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_18__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_18__string = "JALR";
-      default : _zz_18__string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_19_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_19__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_19__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_19__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_19__string = "JALR";
-      default : _zz_19__string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_20__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_20__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_20__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_20__string = "SRA_1    ";
-      default : _zz_20__string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_21__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_21__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_21__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_21__string = "SRA_1    ";
-      default : _zz_21__string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_22__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_22__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_22__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_22__string = "SRA_1    ";
-      default : _zz_22__string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_23__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_23__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_23__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_23__string = "SRA_1    ";
-      default : _zz_23__string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_24__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_24__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_24__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_24__string = "SRA_1    ";
-      default : _zz_24__string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25__string = "BITWISE ";
-      default : _zz_25__string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26__string = "BITWISE ";
-      default : _zz_26__string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_27__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_27__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_27__string = "BITWISE ";
-      default : _zz_27__string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : memory_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : memory_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET";
       default : memory_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33__string = "XRET";
-      default : _zz_33__string = "????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET";
+      default : _zz_memory_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET";
       default : execute_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34__string = "XRET";
-      default : _zz_34__string = "????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET";
+      default : _zz_execute_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : writeBack_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : writeBack_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET";
       default : writeBack_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_37__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_37__string = "XRET";
-      default : _zz_37__string = "????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET";
+      default : _zz_writeBack_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : execute_BRANCH_CTRL_string = "JALR";
+      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_41_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_41__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_41__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41__string = "JALR";
-      default : _zz_41__string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45__string = "SRA_1    ";
-      default : _zz_45__string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_47__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_47__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_47__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_47__string = "SRA_1    ";
-      default : _zz_47__string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : execute_SRC2_CTRL_string = "PC ";
+      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_52__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_52__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_52__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_52__string = "PC ";
-      default : _zz_52__string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_54_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_54__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_54__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_54__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_54__string = "URS1        ";
-      default : _zz_54__string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_57_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_57__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_57__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_57__string = "BITWISE ";
-      default : _zz_57__string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_59_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_59__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_59__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_59__string = "AND_1";
-      default : _zz_59__string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_67_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_67__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_67__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_67__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_67__string = "SRA_1    ";
-      default : _zz_67__string = "?????????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET";
+      default : _zz_decode_ENV_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_70_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_70__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_70__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_70__string = "BITWISE ";
-      default : _zz_70__string = "????????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_74_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_74__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_74__string = "XRET";
-      default : _zz_74__string = "????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_78_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_78__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_78__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_78__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_78__string = "PC ";
-      default : _zz_78__string = "???";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_79_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_79__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_79__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_79__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_79__string = "URS1        ";
-      default : _zz_79__string = "????????????";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_84_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_84__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_84__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_84__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_84__string = "JALR";
-      default : _zz_84__string = "????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_88_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_88__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_88__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_88__string = "AND_1";
-      default : _zz_88__string = "?????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_154_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_154__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_154__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_154__string = "AND_1";
-      default : _zz_154__string = "?????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_155_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_155__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_155__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_155__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_155__string = "JALR";
-      default : _zz_155__string = "????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_156_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_156__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_156__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_156__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_156__string = "URS1        ";
-      default : _zz_156__string = "????????????";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_157_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_157__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_157__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_157__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_157__string = "PC ";
-      default : _zz_157__string = "???";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_158_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_158__string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_158__string = "XRET";
-      default : _zz_158__string = "????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_159_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_159__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_159__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_159__string = "BITWISE ";
-      default : _zz_159__string = "????????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_160_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_160__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_160__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_160__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_160__string = "SRA_1    ";
-      default : _zz_160__string = "?????????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET";
+      default : _zz_decode_ENV_CTRL_2_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET";
       default : decode_to_execute_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET";
       default : execute_to_memory_ENV_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE";
-      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET";
+      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE";
+      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET";
       default : memory_to_writeBack_ENV_CTRL_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   `endif
 
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[32];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[30];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_71_;
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[29];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[27];
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[20];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[19];
+  assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
+  assign decode_PREDICTION_CONTEXT_hazard = IBusCachedPlugin_predictor_injectorContext_hazard;
+  assign decode_PREDICTION_CONTEXT_hit = IBusCachedPlugin_predictor_injectorContext_hit;
+  assign decode_PREDICTION_CONTEXT_line_source = IBusCachedPlugin_predictor_injectorContext_line_source;
+  assign decode_PREDICTION_CONTEXT_line_branchWish = IBusCachedPlugin_predictor_injectorContext_line_branchWish;
+  assign decode_PREDICTION_CONTEXT_line_target = IBusCachedPlugin_predictor_injectorContext_line_target;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
-  assign decode_FORMAL_PC_NEXT = _zz_106_;
-  assign decode_ALU_BITWISE_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
-  assign decode_SRC1_CTRL = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign memory_MUL_LOW = _zz_28_;
-  assign decode_MEMORY_LRSC = _zz_75_;
-  assign decode_IS_RS1_SIGNED = _zz_86_;
-  assign decode_CSR_WRITE_OPCODE = _zz_36_;
-  assign decode_SRC2_FORCE_ZERO = _zz_56_;
-  assign execute_MUL_LH = _zz_31_;
-  assign execute_MUL_LL = _zz_32_;
-  assign decode_CSR_READ_OPCODE = _zz_35_;
-  assign decode_MEMORY_AMO = _zz_65_;
-  assign execute_MUL_HL = _zz_30_;
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_73_;
-  assign decode_MEMORY_MANAGMENT = _zz_82_;
-  assign decode_SRC2_CTRL = _zz_7_;
-  assign _zz_8_ = _zz_9_;
-  assign decode_IS_DIV = _zz_81_;
+  assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_72_;
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_77_;
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = _zz_29_;
-  assign execute_SHIFT_RIGHT = _zz_46_;
-  assign _zz_10_ = _zz_11_;
-  assign _zz_12_ = _zz_13_;
-  assign decode_ENV_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_BRANCH_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign decode_IS_CSR = _zz_90_;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_93_;
-  assign decode_PREDICTION_CONTEXT_hazard = _zz_98_;
-  assign decode_PREDICTION_CONTEXT_hit = _zz_99_;
-  assign decode_PREDICTION_CONTEXT_line_source = _zz_100_;
-  assign decode_PREDICTION_CONTEXT_line_branchWish = _zz_101_;
-  assign decode_PREDICTION_CONTEXT_line_target = _zz_102_;
-  assign execute_REGFILE_WRITE_DATA = _zz_58_;
-  assign decode_IS_RS2_SIGNED = _zz_69_;
-  assign _zz_20_ = _zz_21_;
-  assign decode_SHIFT_CTRL = _zz_22_;
-  assign _zz_23_ = _zz_24_;
-  assign decode_SRC_LESS_UNSIGNED = _zz_68_;
-  assign decode_ALU_CTRL = _zz_25_;
-  assign _zz_26_ = _zz_27_;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3607,22 +2603,23 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_33_;
-  assign execute_ENV_CTRL = _zz_34_;
-  assign writeBack_ENV_CTRL = _zz_37_;
-  assign execute_NEXT_PC2 = _zz_39_;
-  assign execute_TARGET_MISSMATCH2 = _zz_38_;
-  assign execute_BRANCH_DO = _zz_42_;
-  assign execute_BRANCH_CALC = _zz_40_;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
+  assign execute_NEXT_PC2 = (execute_PC + 32'h00000004);
+  assign execute_TARGET_MISSMATCH2 = (decode_PC != execute_BRANCH_CALC);
+  assign execute_BRANCH_DO = _zz_execute_BRANCH_DO_1;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_SRC22 = _zz_execute_BRANCH_SRC22_6;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_41_;
-  assign decode_RS2_USE = _zz_89_;
-  assign decode_RS1_USE = _zz_85_;
-  always @ (*) begin
-    _zz_43_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_243_)begin
-      _zz_43_ = execute_CsrPlugin_readData;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -3632,331 +2629,343 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    decode_RS2 = _zz_63_;
-    if(_zz_174_)begin
-      if((_zz_175_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_176_;
+  always @(*) begin
+    decode_RS2 = decode_RegFilePlugin_rs2Data;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_244_)begin
-      if(_zz_245_)begin
-        if(_zz_178_)begin
-          decode_RS2 = _zz_92_;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_246_)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_180_)begin
-          decode_RS2 = _zz_44_;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_247_)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_182_)begin
-          decode_RS2 = _zz_43_;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
-    decode_RS1 = _zz_64_;
-    if(_zz_174_)begin
-      if((_zz_175_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_176_;
+  always @(*) begin
+    decode_RS1 = decode_RegFilePlugin_rs1Data;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_244_)begin
-      if(_zz_245_)begin
-        if(_zz_177_)begin
-          decode_RS1 = _zz_92_;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_246_)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_179_)begin
-          decode_RS1 = _zz_44_;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_247_)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_181_)begin
-          decode_RS1 = _zz_43_;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_44_ = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_44_ = _zz_170_;
+        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_44_ = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_248_)begin
-      _zz_44_ = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_45_;
-  assign execute_SHIFT_CTRL = _zz_47_;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_51_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_52_;
-  assign execute_SRC1_CTRL = _zz_54_;
-  assign decode_SRC_USE_SUB_LESS = _zz_76_;
-  assign decode_SRC_ADD_ZERO = _zz_80_;
-  assign execute_SRC_ADD_SUB = _zz_50_;
-  assign execute_SRC_LESS = _zz_48_;
-  assign execute_ALU_CTRL = _zz_57_;
-  assign execute_SRC2 = _zz_53_;
-  assign execute_SRC1 = _zz_55_;
-  assign execute_ALU_BITWISE_CTRL = _zz_59_;
-  assign _zz_60_ = writeBack_INSTRUCTION;
-  assign _zz_61_ = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_62_ = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_62_ = 1'b1;
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[18];
+  assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
+  assign execute_SRC_LESS = execute_SrcPlugin_less;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
-  assign decode_INSTRUCTION_ANTICIPATED = _zz_97_;
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_66_;
-    if((decode_INSTRUCTION[11 : 7] == (5'b00000)))begin
+  assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = _zz_91_;
-  assign decode_INSTRUCTION_READY = 1'b1;
-  always @ (*) begin
-    _zz_92_ = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_92_ = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_276_)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_92_ = _zz_346_;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_92_ = _zz_347_;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_LRSC = memory_to_writeBack_MEMORY_LRSC;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
   assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
-  assign execute_SRC_ADD = _zz_49_;
+  assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_87_;
-  assign decode_FLUSH_ALL = _zz_83_;
-  always @ (*) begin
-    IBusCachedPlugin_rsp_issueDetected = _zz_94_;
-    if(_zz_249_)begin
-      IBusCachedPlugin_rsp_issueDetected = 1'b1;
+  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(when_IBusCachedPlugin_l256) begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_94_ = _zz_95_;
-    if(_zz_250_)begin
-      _zz_94_ = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_95_ = _zz_96_;
-    if(_zz_251_)begin
-      _zz_95_ = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(when_IBusCachedPlugin_l244) begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_96_ = 1'b0;
-    if(_zz_252_)begin
-      _zz_96_ = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(when_IBusCachedPlugin_l239) begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_INSTRUCTION = _zz_107_;
+  assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   assign execute_PREDICTION_CONTEXT_hazard = decode_to_execute_PREDICTION_CONTEXT_hazard;
   assign execute_PREDICTION_CONTEXT_hit = decode_to_execute_PREDICTION_CONTEXT_hit;
   assign execute_PREDICTION_CONTEXT_line_source = decode_to_execute_PREDICTION_CONTEXT_line_source;
   assign execute_PREDICTION_CONTEXT_line_branchWish = decode_to_execute_PREDICTION_CONTEXT_line_branchWish;
   assign execute_PREDICTION_CONTEXT_line_target = decode_to_execute_PREDICTION_CONTEXT_line_target;
-  always @ (*) begin
-    _zz_103_ = 1'b0;
-    if(IBusCachedPlugin_predictor_historyWrite_valid)begin
-      _zz_103_ = 1'b1;
+  always @(*) begin
+    _zz_2 = 1'b0;
+    if(IBusCachedPlugin_predictor_historyWriteDelayPatched_valid) begin
+      _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_104_ = execute_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_104_ = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_execute_to_memory_FORMAL_PC_NEXT = execute_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_execute_to_memory_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_105_ = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_redoBranch_valid)begin
-      _zz_105_ = IBusCachedPlugin_redoBranch_payload;
-    end
-  end
-
-  assign decode_PC = _zz_108_;
+  assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_171_ || _zz_172_)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts))begin
-      decode_arbitration_haltByOther = decode_arbitration_isValid;
+    if(CsrPlugin_pipelineLiberator_active) begin
+      decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_253_)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
-    decode_arbitration_flushAll = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
-      decode_arbitration_flushAll = 1'b1;
-    end
-    if(BranchPlugin_branchExceptionPort_valid)begin
-      decode_arbitration_flushAll = 1'b1;
+  assign decode_arbitration_flushIt = 1'b0;
+  always @(*) begin
+    decode_arbitration_flushNext = 1'b0;
+    if(_zz_when) begin
+      decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_237_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_243_)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if(when_DBusCachedPlugin_l359) begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  assign execute_arbitration_flushAll = 1'b0;
-  always @ (*) begin
+  assign execute_arbitration_flushIt = 1'b0;
+  always @(*) begin
+    execute_arbitration_flushNext = 1'b0;
+    if(BranchPlugin_jumpInterface_valid) begin
+      execute_arbitration_flushNext = 1'b1;
+    end
+    if(BranchPlugin_branchExceptionPort_valid) begin
+      execute_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_248_)begin
-      if(_zz_254_)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
-    memory_arbitration_flushAll = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
-      memory_arbitration_flushAll = 1'b1;
-    end
-    if(_zz_255_)begin
-      memory_arbitration_flushAll = 1'b1;
-    end
-    if(_zz_256_)begin
-      memory_arbitration_flushAll = 1'b1;
-    end
-  end
-
-  always @ (*) begin
+  assign memory_arbitration_flushIt = 1'b0;
+  assign memory_arbitration_flushNext = 1'b0;
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
-    writeBack_arbitration_flushAll = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
-      writeBack_arbitration_flushAll = 1'b1;
+  always @(*) begin
+    writeBack_arbitration_flushIt = 1'b0;
+    if(DBusCachedPlugin_redoBranch_valid) begin
+      writeBack_arbitration_flushIt = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    writeBack_arbitration_flushNext = 1'b0;
+    if(DBusCachedPlugin_redoBranch_valid) begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+    if(DBusCachedPlugin_exceptionBus_valid) begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+    if(when_CsrPlugin_l1019) begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+    if(when_CsrPlugin_l1064) begin
+      writeBack_arbitration_flushNext = 1'b1;
     end
   end
 
@@ -3964,44 +2973,47 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode}}} != (4'b0000)))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_255_)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_256_)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_fetcherflushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  assign CsrPlugin_inWfi = 1'b0;
+  assign CsrPlugin_thirdPartyWake = 1'b0;
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_255_)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_256_)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = (32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
-    if(_zz_255_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_256_)begin
-      case(_zz_257_)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4014,155 +3026,183 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_redoBranch_valid}}} != (4'b0000));
-  assign _zz_109_ = {IBusCachedPlugin_redoBranch_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_110_ = (_zz_109_ & (~ _zz_277_));
-  assign _zz_111_ = _zz_110_[3];
-  assign _zz_112_ = (_zz_110_[1] || _zz_111_);
-  assign _zz_113_ = (_zz_110_[2] || _zz_111_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_242_;
-  assign _zz_114_ = (! IBusCachedPlugin_fetcherHalt);
-  assign IBusCachedPlugin_fetchPc_output_valid = (IBusCachedPlugin_fetchPc_preOutput_valid && _zz_114_);
-  assign IBusCachedPlugin_fetchPc_preOutput_ready = (IBusCachedPlugin_fetchPc_output_ready && _zz_114_);
-  assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_preOutput_payload;
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_propagatePc = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid && IBusCachedPlugin_iBusRsp_stages_1_input_ready))begin
-      IBusCachedPlugin_fetchPc_propagatePc = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}} != 3'b000);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[1];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_correction = 1'b0;
+    if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid) begin
+      IBusCachedPlugin_fetchPc_correction = 1'b1;
+    end
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
+      IBusCachedPlugin_fetchPc_correction = 1'b1;
+    end
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
+      IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_279_);
-    if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid)begin
+  assign IBusCachedPlugin_fetchPc_output_fire = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
+  assign IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_predictionPcLoad_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
+      IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
+    end
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_samplePcNext = 1'b0;
-    if(IBusCachedPlugin_fetchPc_propagatePc)begin
-      IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_flushed = 1'b0;
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
+      IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid)begin
-      IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
-    end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
-      IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
-    end
-    if(_zz_258_)begin
-      IBusCachedPlugin_fetchPc_samplePcNext = 1'b1;
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
+      IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_fetchPc_preOutput_valid = _zz_115_;
-  assign IBusCachedPlugin_fetchPc_preOutput_payload = IBusCachedPlugin_fetchPc_pc;
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
+  assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
+  always @(*) begin
+    IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
+    if(IBusCachedPlugin_rsp_redoFetch) begin
+      IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
+    end
+  end
+
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  assign IBusCachedPlugin_iBusRsp_stages_0_inputSample = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_116_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_116_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_116_);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_117_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_117_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_117_);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
-    IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
-      IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
+    if(when_IBusCachedPlugin_l267) begin
+      IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_118_ = (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_halt);
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_ready && _zz_118_);
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_valid = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid && _zz_118_);
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_payload = IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload;
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_119_;
-  assign _zz_119_ = ((1'b0 && (! _zz_120_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_120_ = _zz_121_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_120_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_122_)) || IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready);
-  assign _zz_122_ = _zz_123_;
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid = _zz_122_;
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload = _zz_124_;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
+  assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
+  assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
+  assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  assign IBusCachedPlugin_iBusRsp_decodeInput_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = (IBusCachedPlugin_iBusRsp_decodeInput_valid && (! IBusCachedPlugin_injector_decodeRemoved));
-  assign _zz_108_ = IBusCachedPlugin_iBusRsp_decodeInput_payload_pc;
-  assign _zz_107_ = IBusCachedPlugin_iBusRsp_decodeInput_payload_rsp_inst;
-  assign _zz_106_ = (decode_PC + (32'b00000000000000000000000000000100));
-  assign _zz_125_ = (IBusCachedPlugin_iBusRsp_stages_0_input_payload >>> 2);
-  assign _zz_126_ = (IBusCachedPlugin_iBusRsp_stages_0_output_ready || (IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt));
-  assign _zz_127_ = _zz_239_;
-  assign IBusCachedPlugin_predictor_line_source = _zz_127_[19 : 0];
-  assign IBusCachedPlugin_predictor_line_branchWish = _zz_127_[21 : 20];
-  assign IBusCachedPlugin_predictor_line_target = _zz_127_[53 : 22];
-  assign IBusCachedPlugin_predictor_hit = ((IBusCachedPlugin_predictor_line_source == _zz_281_) && 1'b1);
-  assign IBusCachedPlugin_predictor_hazard = (IBusCachedPlugin_predictor_historyWriteLast_valid && (IBusCachedPlugin_predictor_historyWriteLast_payload_address == _zz_283_));
-  assign IBusCachedPlugin_fetchPc_predictionPcLoad_valid = (((IBusCachedPlugin_predictor_line_branchWish[1] && IBusCachedPlugin_predictor_hit) && (! IBusCachedPlugin_predictor_hazard)) && (IBusCachedPlugin_iBusRsp_stages_1_output_valid && IBusCachedPlugin_iBusRsp_stages_1_output_ready));
+  assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
+  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  assign IBusCachedPlugin_predictor_historyWriteDelayPatched_valid = IBusCachedPlugin_predictor_historyWrite_valid;
+  assign IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_address = (IBusCachedPlugin_predictor_historyWrite_payload_address - 10'h001);
+  assign IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_source = IBusCachedPlugin_predictor_historyWrite_payload_data_source;
+  assign IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_branchWish = IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
+  assign IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_target = IBusCachedPlugin_predictor_historyWrite_payload_data_target;
+  assign _zz_IBusCachedPlugin_predictor_buffer_line_source = (IBusCachedPlugin_iBusRsp_stages_0_input_payload >>> 2);
+  assign _zz_IBusCachedPlugin_predictor_buffer_line_source_1 = _zz_IBusCachedPlugin_predictor_history_port1;
+  assign IBusCachedPlugin_predictor_buffer_line_source = _zz_IBusCachedPlugin_predictor_buffer_line_source_1[19 : 0];
+  assign IBusCachedPlugin_predictor_buffer_line_branchWish = _zz_IBusCachedPlugin_predictor_buffer_line_source_1[21 : 20];
+  assign IBusCachedPlugin_predictor_buffer_line_target = _zz_IBusCachedPlugin_predictor_buffer_line_source_1[53 : 22];
+  assign IBusCachedPlugin_predictor_buffer_hazard = (IBusCachedPlugin_predictor_writeLast_valid && (IBusCachedPlugin_predictor_writeLast_payload_address == _zz_IBusCachedPlugin_predictor_buffer_hazard));
+  assign IBusCachedPlugin_predictor_hazard = (IBusCachedPlugin_predictor_buffer_hazard_regNextWhen || IBusCachedPlugin_predictor_buffer_pcCorrected);
+  assign IBusCachedPlugin_predictor_hit = (IBusCachedPlugin_predictor_line_source == _zz_IBusCachedPlugin_predictor_hit);
+  assign IBusCachedPlugin_fetchPc_predictionPcLoad_valid = (((IBusCachedPlugin_predictor_line_branchWish[1] && IBusCachedPlugin_predictor_hit) && (! IBusCachedPlugin_predictor_hazard)) && IBusCachedPlugin_iBusRsp_stages_1_input_valid);
   assign IBusCachedPlugin_fetchPc_predictionPcLoad_payload = IBusCachedPlugin_predictor_line_target;
   assign IBusCachedPlugin_predictor_fetchContext_hazard = IBusCachedPlugin_predictor_hazard;
   assign IBusCachedPlugin_predictor_fetchContext_hit = IBusCachedPlugin_predictor_hit;
   assign IBusCachedPlugin_predictor_fetchContext_line_source = IBusCachedPlugin_predictor_line_source;
   assign IBusCachedPlugin_predictor_fetchContext_line_branchWish = IBusCachedPlugin_predictor_line_branchWish;
   assign IBusCachedPlugin_predictor_fetchContext_line_target = IBusCachedPlugin_predictor_line_target;
-  assign IBusCachedPlugin_predictor_injectorContext_hazard = IBusCachedPlugin_predictor_fetchContext_regNextWhen_hazard;
-  assign IBusCachedPlugin_predictor_injectorContext_hit = IBusCachedPlugin_predictor_fetchContext_regNextWhen_hit;
-  assign IBusCachedPlugin_predictor_injectorContext_line_source = IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_source;
-  assign IBusCachedPlugin_predictor_injectorContext_line_branchWish = IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_branchWish;
-  assign IBusCachedPlugin_predictor_injectorContext_line_target = IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_target;
-  assign _zz_98_ = IBusCachedPlugin_predictor_injectorContext_hazard;
-  assign _zz_99_ = IBusCachedPlugin_predictor_injectorContext_hit;
-  assign _zz_100_ = IBusCachedPlugin_predictor_injectorContext_line_source;
-  assign _zz_101_ = IBusCachedPlugin_predictor_injectorContext_line_branchWish;
-  assign _zz_102_ = IBusCachedPlugin_predictor_injectorContext_line_target;
+  assign IBusCachedPlugin_predictor_iBusRspContextOutput_hazard = IBusCachedPlugin_predictor_iBusRspContext_hazard;
+  assign IBusCachedPlugin_predictor_iBusRspContextOutput_hit = IBusCachedPlugin_predictor_iBusRspContext_hit;
+  assign IBusCachedPlugin_predictor_iBusRspContextOutput_line_source = IBusCachedPlugin_predictor_iBusRspContext_line_source;
+  assign IBusCachedPlugin_predictor_iBusRspContextOutput_line_branchWish = IBusCachedPlugin_predictor_iBusRspContext_line_branchWish;
+  assign IBusCachedPlugin_predictor_iBusRspContextOutput_line_target = IBusCachedPlugin_predictor_iBusRspContext_line_target;
+  assign IBusCachedPlugin_predictor_injectorContext_hazard = IBusCachedPlugin_predictor_iBusRspContextOutput_hazard;
+  assign IBusCachedPlugin_predictor_injectorContext_hit = IBusCachedPlugin_predictor_iBusRspContextOutput_hit;
+  assign IBusCachedPlugin_predictor_injectorContext_line_source = IBusCachedPlugin_predictor_iBusRspContextOutput_line_source;
+  assign IBusCachedPlugin_predictor_injectorContext_line_branchWish = IBusCachedPlugin_predictor_iBusRspContextOutput_line_branchWish;
+  assign IBusCachedPlugin_predictor_injectorContext_line_target = IBusCachedPlugin_predictor_iBusRspContextOutput_line_target;
   assign IBusCachedPlugin_fetchPrediction_cmd_hadBranch = ((execute_PREDICTION_CONTEXT_hit && (! execute_PREDICTION_CONTEXT_hazard)) && execute_PREDICTION_CONTEXT_line_branchWish[1]);
   assign IBusCachedPlugin_fetchPrediction_cmd_targetPc = execute_PREDICTION_CONTEXT_line_target;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_predictor_historyWrite_valid = 1'b0;
-    if(IBusCachedPlugin_fetchPrediction_rsp_wasRight)begin
+    if(IBusCachedPlugin_fetchPrediction_rsp_wasRight) begin
       IBusCachedPlugin_predictor_historyWrite_valid = execute_PREDICTION_CONTEXT_hit;
     end else begin
-      if(execute_PREDICTION_CONTEXT_hit)begin
+      if(execute_PREDICTION_CONTEXT_hit) begin
         IBusCachedPlugin_predictor_historyWrite_valid = 1'b1;
       end else begin
         IBusCachedPlugin_predictor_historyWrite_valid = 1'b1;
       end
     end
-    if((execute_PREDICTION_CONTEXT_hazard || (! execute_arbitration_isFiring)))begin
+    if(when_Fetcher_l596) begin
       IBusCachedPlugin_predictor_historyWrite_valid = 1'b0;
     end
   end
@@ -4170,368 +3210,396 @@ module VexRiscv (
   assign IBusCachedPlugin_predictor_historyWrite_payload_address = IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord[11 : 2];
   assign IBusCachedPlugin_predictor_historyWrite_payload_data_source = (IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord >>> 12);
   assign IBusCachedPlugin_predictor_historyWrite_payload_data_target = IBusCachedPlugin_fetchPrediction_rsp_finalPc;
-  always @ (*) begin
-    if(IBusCachedPlugin_fetchPrediction_rsp_wasRight)begin
-      IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (_zz_284_ - _zz_288_);
+  always @(*) begin
+    if(IBusCachedPlugin_fetchPrediction_rsp_wasRight) begin
+      IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (_zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish - _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_3);
     end else begin
-      if(execute_PREDICTION_CONTEXT_hit)begin
-        IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (_zz_289_ + _zz_293_);
+      if(execute_PREDICTION_CONTEXT_hit) begin
+        IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (_zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_5 + _zz_IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish_8);
       end else begin
-        IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = (2'b10);
+        IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish = 2'b10;
       end
     end
   end
 
+  assign when_Fetcher_l596 = (execute_PREDICTION_CONTEXT_hazard || (! execute_arbitration_isFiring));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_217_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_220_ = (IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt);
-  assign _zz_221_ = (32'b00000000000000000000000000000000);
-  assign _zz_218_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_219_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_222_ = (IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_223_ = (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready);
-  assign _zz_224_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_97_ = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
-  always @ (*) begin
+  assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_252_)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_250_)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
-    end
-    if((! IBusCachedPlugin_iBusRsp_readyForError))begin
-      IBusCachedPlugin_rsp_redoFetch = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_225_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_250_)begin
-      _zz_225_ = 1'b1;
-    end
-    if((! IBusCachedPlugin_iBusRsp_readyForError))begin
-      _zz_225_ = 1'b0;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_251_)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_249_)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
-    end
-    if(IBusCachedPlugin_fetcherHalt)begin
-      IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_251_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+  always @(*) begin
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(when_IBusCachedPlugin_l244) begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_249_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(when_IBusCachedPlugin_l256) begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload[31 : 2],(2'b00)};
-  assign IBusCachedPlugin_redoBranch_valid = IBusCachedPlugin_rsp_redoFetch;
-  assign IBusCachedPlugin_redoBranch_payload = IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_payload;
-  assign IBusCachedPlugin_iBusRsp_decodeInput_valid = IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_valid;
-  assign IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_ready = IBusCachedPlugin_iBusRsp_decodeInput_ready;
-  assign IBusCachedPlugin_iBusRsp_decodeInput_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
-  assign IBusCachedPlugin_iBusRsp_decodeInput_payload_pc = IBusCachedPlugin_iBusRsp_cacheRspArbitration_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_216_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || _zz_128_);
-  assign _zz_238_ = (! _zz_128_);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (_zz_128_ ? _zz_129_ : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (_zz_128_ ? _zz_130_ : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (_zz_128_ ? _zz_131_ : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (_zz_128_ ? _zz_132_ : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (_zz_128_ ? _zz_133_ : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (_zz_128_ ? _zz_134_ : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = _zz_135_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = _zz_136_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = _zz_137_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = _zz_138_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = _zz_139_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = _zz_140_;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = _zz_141_;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
+  assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
+  assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  always @(*) begin
+    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l342) begin
+      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    end
+  end
+
+  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  always @(*) begin
+    _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
+    if(when_DBusCachedPlugin_l311) begin
+      if(decode_MEMORY_LRSC) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
+      end
+      if(decode_MEMORY_AMO) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
+      end
+    end
+  end
+
+  assign when_DBusCachedPlugin_l311 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_226_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_227_ = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_142_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_142_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_142_ = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_237_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  always @ (*) begin
-    _zz_228_ = 1'b0;
-    if(execute_MEMORY_LRSC)begin
-      _zz_228_ = 1'b1;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
+    if(execute_MEMORY_LRSC) begin
+      dataCache_1_io_cpu_execute_args_isLrsc = 1'b1;
     end
   end
 
-  assign _zz_230_ = execute_INSTRUCTION[31 : 29];
-  assign _zz_229_ = execute_INSTRUCTION[27];
-  assign _zz_93_ = _zz_227_[1 : 0];
-  assign _zz_231_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_232_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  always @ (*) begin
-    _zz_233_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_233_ = 1'b1;
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_234_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_235_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_236_ = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_259_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_259_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_259_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_294_};
+  always @(*) begin
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_295_};
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_143_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_144_[31] = _zz_143_;
-    _zz_144_[30] = _zz_143_;
-    _zz_144_[29] = _zz_143_;
-    _zz_144_[28] = _zz_143_;
-    _zz_144_[27] = _zz_143_;
-    _zz_144_[26] = _zz_143_;
-    _zz_144_[25] = _zz_143_;
-    _zz_144_[24] = _zz_143_;
-    _zz_144_[23] = _zz_143_;
-    _zz_144_[22] = _zz_143_;
-    _zz_144_[21] = _zz_143_;
-    _zz_144_[20] = _zz_143_;
-    _zz_144_[19] = _zz_143_;
-    _zz_144_[18] = _zz_143_;
-    _zz_144_[17] = _zz_143_;
-    _zz_144_[16] = _zz_143_;
-    _zz_144_[15] = _zz_143_;
-    _zz_144_[14] = _zz_143_;
-    _zz_144_[13] = _zz_143_;
-    _zz_144_[12] = _zz_143_;
-    _zz_144_[11] = _zz_143_;
-    _zz_144_[10] = _zz_143_;
-    _zz_144_[9] = _zz_143_;
-    _zz_144_[8] = _zz_143_;
-    _zz_144_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+    if(when_DBusCachedPlugin_l474) begin
+      writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
+    end
   end
 
-  assign _zz_145_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_146_[31] = _zz_145_;
-    _zz_146_[30] = _zz_145_;
-    _zz_146_[29] = _zz_145_;
-    _zz_146_[28] = _zz_145_;
-    _zz_146_[27] = _zz_145_;
-    _zz_146_[26] = _zz_145_;
-    _zz_146_[25] = _zz_145_;
-    _zz_146_[24] = _zz_145_;
-    _zz_146_[23] = _zz_145_;
-    _zz_146_[22] = _zz_145_;
-    _zz_146_[21] = _zz_145_;
-    _zz_146_[20] = _zz_145_;
-    _zz_146_[19] = _zz_145_;
-    _zz_146_[18] = _zz_145_;
-    _zz_146_[17] = _zz_145_;
-    _zz_146_[16] = _zz_145_;
-    _zz_146_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign when_DBusCachedPlugin_l474 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_274_)
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l200)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_144_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_146_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_148_ = ((decode_INSTRUCTION & (32'b00000000000000000010000001010000)) == (32'b00000000000000000010000000000000));
-  assign _zz_149_ = ((decode_INSTRUCTION & (32'b00000000000000000001000000000000)) == (32'b00000000000000000000000000000000));
-  assign _zz_150_ = ((decode_INSTRUCTION & (32'b00000000000000000000000001001000)) == (32'b00000000000000000000000001001000));
-  assign _zz_151_ = ((decode_INSTRUCTION & (32'b00000000000000000100000001010000)) == (32'b00000000000000000100000001010000));
-  assign _zz_152_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000000100)) == (32'b00000000000000000000000000000100));
-  assign _zz_153_ = ((decode_INSTRUCTION & (32'b00000000000000000000000000001100)) == (32'b00000000000000000000000000000100));
-  assign _zz_147_ = {(((decode_INSTRUCTION & _zz_374_) == (32'b00000000000000000000000000001000)) != (1'b0)),{({_zz_150_,{_zz_375_,_zz_376_}} != (7'b0000000)),{({_zz_377_,_zz_378_} != (4'b0000)),{(_zz_379_ != _zz_380_),{_zz_381_,{_zz_382_,_zz_383_}}}}}};
-  assign _zz_91_ = ({((decode_INSTRUCTION & (32'b00000000000000000000000001011111)) == (32'b00000000000000000000000000010111)),{((decode_INSTRUCTION & (32'b00000000000000000000000001111111)) == (32'b00000000000000000000000001101111)),{((decode_INSTRUCTION & (32'b00000000000000000001000001101111)) == (32'b00000000000000000000000000000011)),{((decode_INSTRUCTION & _zz_554_) == (32'b00000000000000000001000001110011)),{(_zz_555_ == _zz_556_),{_zz_557_,{_zz_558_,_zz_559_}}}}}}} != (22'b0000000000000000000000));
-  assign _zz_90_ = _zz_296_[0];
-  assign _zz_89_ = _zz_297_[0];
-  assign _zz_154_ = _zz_147_[3 : 2];
-  assign _zz_88_ = _zz_154_;
-  assign _zz_87_ = _zz_298_[0];
-  assign _zz_86_ = _zz_299_[0];
-  assign _zz_85_ = _zz_300_[0];
-  assign _zz_155_ = _zz_147_[8 : 7];
-  assign _zz_84_ = _zz_155_;
-  assign _zz_83_ = _zz_301_[0];
-  assign _zz_82_ = _zz_302_[0];
-  assign _zz_81_ = _zz_303_[0];
-  assign _zz_80_ = _zz_304_[0];
-  assign _zz_156_ = _zz_147_[14 : 13];
-  assign _zz_79_ = _zz_156_;
-  assign _zz_157_ = _zz_147_[16 : 15];
-  assign _zz_78_ = _zz_157_;
-  assign _zz_77_ = _zz_305_[0];
-  assign _zz_76_ = _zz_306_[0];
-  assign _zz_75_ = _zz_307_[0];
-  assign _zz_158_ = _zz_147_[20 : 20];
-  assign _zz_74_ = _zz_158_;
-  assign _zz_73_ = _zz_308_[0];
-  assign _zz_72_ = _zz_309_[0];
-  assign _zz_71_ = _zz_310_[0];
-  assign _zz_159_ = _zz_147_[25 : 24];
-  assign _zz_70_ = _zz_159_;
-  assign _zz_69_ = _zz_311_[0];
-  assign _zz_68_ = _zz_312_[0];
-  assign _zz_160_ = _zz_147_[29 : 28];
-  assign _zz_67_ = _zz_160_;
-  assign _zz_66_ = _zz_313_[0];
-  assign _zz_65_ = _zz_314_[0];
-  assign decodeExceptionPort_valid = ((decode_arbitration_isValid && decode_INSTRUCTION_READY) && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_6 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_6 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_12}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[26 : 25];
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[28 : 28];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
+  assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_240_;
-  assign decode_RegFilePlugin_rs2Data = _zz_241_;
-  assign _zz_64_ = decode_RegFilePlugin_rs1Data;
-  assign _zz_63_ = decode_RegFilePlugin_rs2Data;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_61_ && writeBack_arbitration_isFiring);
-    if(_zz_161_)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_3) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_60_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_92_;
-  always @ (*) begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_3) begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_3) begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -4540,468 +3608,493 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_162_ = execute_IntAluPlugin_bitwise;
+      `AluCtrlEnum_binary_sequential_BITWISE : begin
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_162_ = {31'd0, _zz_315_};
+      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_162_ = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  assign _zz_58_ = _zz_162_;
-  assign _zz_56_ = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_163_ = execute_RS1;
+      `Src1CtrlEnum_binary_sequential_RS : begin
+        _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_163_ = {29'd0, _zz_316_};
+      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_163_ = {execute_INSTRUCTION[31 : 12],(12'b000000000000)};
+      `Src1CtrlEnum_binary_sequential_IMU : begin
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_163_ = {27'd0, _zz_317_};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_55_ = _zz_163_;
-  assign _zz_164_ = _zz_318_[11];
-  always @ (*) begin
-    _zz_165_[19] = _zz_164_;
-    _zz_165_[18] = _zz_164_;
-    _zz_165_[17] = _zz_164_;
-    _zz_165_[16] = _zz_164_;
-    _zz_165_[15] = _zz_164_;
-    _zz_165_[14] = _zz_164_;
-    _zz_165_[13] = _zz_164_;
-    _zz_165_[12] = _zz_164_;
-    _zz_165_[11] = _zz_164_;
-    _zz_165_[10] = _zz_164_;
-    _zz_165_[9] = _zz_164_;
-    _zz_165_[8] = _zz_164_;
-    _zz_165_[7] = _zz_164_;
-    _zz_165_[6] = _zz_164_;
-    _zz_165_[5] = _zz_164_;
-    _zz_165_[4] = _zz_164_;
-    _zz_165_[3] = _zz_164_;
-    _zz_165_[2] = _zz_164_;
-    _zz_165_[1] = _zz_164_;
-    _zz_165_[0] = _zz_164_;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_166_ = _zz_319_[11];
-  always @ (*) begin
-    _zz_167_[19] = _zz_166_;
-    _zz_167_[18] = _zz_166_;
-    _zz_167_[17] = _zz_166_;
-    _zz_167_[16] = _zz_166_;
-    _zz_167_[15] = _zz_166_;
-    _zz_167_[14] = _zz_166_;
-    _zz_167_[13] = _zz_166_;
-    _zz_167_[12] = _zz_166_;
-    _zz_167_[11] = _zz_166_;
-    _zz_167_[10] = _zz_166_;
-    _zz_167_[9] = _zz_166_;
-    _zz_167_[8] = _zz_166_;
-    _zz_167_[7] = _zz_166_;
-    _zz_167_[6] = _zz_166_;
-    _zz_167_[5] = _zz_166_;
-    _zz_167_[4] = _zz_166_;
-    _zz_167_[3] = _zz_166_;
-    _zz_167_[2] = _zz_166_;
-    _zz_167_[1] = _zz_166_;
-    _zz_167_[0] = _zz_166_;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_168_ = execute_RS2;
+      `Src2CtrlEnum_binary_sequential_RS : begin
+        _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_168_ = {_zz_165_,execute_INSTRUCTION[31 : 20]};
+      `Src2CtrlEnum_binary_sequential_IMI : begin
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_168_ = {_zz_167_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+      `Src2CtrlEnum_binary_sequential_IMS : begin
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_168_ = _zz_51_;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  assign _zz_53_ = _zz_168_;
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_320_;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign _zz_50_ = execute_SrcPlugin_addSub;
-  assign _zz_49_ = execute_SrcPlugin_addSub;
-  assign _zz_48_ = execute_SrcPlugin_less;
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_169_[0] = execute_SRC1[31];
-    _zz_169_[1] = execute_SRC1[30];
-    _zz_169_[2] = execute_SRC1[29];
-    _zz_169_[3] = execute_SRC1[28];
-    _zz_169_[4] = execute_SRC1[27];
-    _zz_169_[5] = execute_SRC1[26];
-    _zz_169_[6] = execute_SRC1[25];
-    _zz_169_[7] = execute_SRC1[24];
-    _zz_169_[8] = execute_SRC1[23];
-    _zz_169_[9] = execute_SRC1[22];
-    _zz_169_[10] = execute_SRC1[21];
-    _zz_169_[11] = execute_SRC1[20];
-    _zz_169_[12] = execute_SRC1[19];
-    _zz_169_[13] = execute_SRC1[18];
-    _zz_169_[14] = execute_SRC1[17];
-    _zz_169_[15] = execute_SRC1[16];
-    _zz_169_[16] = execute_SRC1[15];
-    _zz_169_[17] = execute_SRC1[14];
-    _zz_169_[18] = execute_SRC1[13];
-    _zz_169_[19] = execute_SRC1[12];
-    _zz_169_[20] = execute_SRC1[11];
-    _zz_169_[21] = execute_SRC1[10];
-    _zz_169_[22] = execute_SRC1[9];
-    _zz_169_[23] = execute_SRC1[8];
-    _zz_169_[24] = execute_SRC1[7];
-    _zz_169_[25] = execute_SRC1[6];
-    _zz_169_[26] = execute_SRC1[5];
-    _zz_169_[27] = execute_SRC1[4];
-    _zz_169_[28] = execute_SRC1[3];
-    _zz_169_[29] = execute_SRC1[2];
-    _zz_169_[30] = execute_SRC1[1];
-    _zz_169_[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_169_ : execute_SRC1);
-  assign _zz_46_ = _zz_328_;
-  always @ (*) begin
-    _zz_170_[0] = memory_SHIFT_RIGHT[31];
-    _zz_170_[1] = memory_SHIFT_RIGHT[30];
-    _zz_170_[2] = memory_SHIFT_RIGHT[29];
-    _zz_170_[3] = memory_SHIFT_RIGHT[28];
-    _zz_170_[4] = memory_SHIFT_RIGHT[27];
-    _zz_170_[5] = memory_SHIFT_RIGHT[26];
-    _zz_170_[6] = memory_SHIFT_RIGHT[25];
-    _zz_170_[7] = memory_SHIFT_RIGHT[24];
-    _zz_170_[8] = memory_SHIFT_RIGHT[23];
-    _zz_170_[9] = memory_SHIFT_RIGHT[22];
-    _zz_170_[10] = memory_SHIFT_RIGHT[21];
-    _zz_170_[11] = memory_SHIFT_RIGHT[20];
-    _zz_170_[12] = memory_SHIFT_RIGHT[19];
-    _zz_170_[13] = memory_SHIFT_RIGHT[18];
-    _zz_170_[14] = memory_SHIFT_RIGHT[17];
-    _zz_170_[15] = memory_SHIFT_RIGHT[16];
-    _zz_170_[16] = memory_SHIFT_RIGHT[15];
-    _zz_170_[17] = memory_SHIFT_RIGHT[14];
-    _zz_170_[18] = memory_SHIFT_RIGHT[13];
-    _zz_170_[19] = memory_SHIFT_RIGHT[12];
-    _zz_170_[20] = memory_SHIFT_RIGHT[11];
-    _zz_170_[21] = memory_SHIFT_RIGHT[10];
-    _zz_170_[22] = memory_SHIFT_RIGHT[9];
-    _zz_170_[23] = memory_SHIFT_RIGHT[8];
-    _zz_170_[24] = memory_SHIFT_RIGHT[7];
-    _zz_170_[25] = memory_SHIFT_RIGHT[6];
-    _zz_170_[26] = memory_SHIFT_RIGHT[5];
-    _zz_170_[27] = memory_SHIFT_RIGHT[4];
-    _zz_170_[28] = memory_SHIFT_RIGHT[3];
-    _zz_170_[29] = memory_SHIFT_RIGHT[2];
-    _zz_170_[30] = memory_SHIFT_RIGHT[1];
-    _zz_170_[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_171_ = 1'b0;
-    if(_zz_260_)begin
-      if(_zz_261_)begin
-        if(_zz_177_)begin
-          _zz_171_ = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_262_)begin
-      if(_zz_263_)begin
-        if(_zz_179_)begin
-          _zz_171_ = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_264_)begin
-      if(_zz_265_)begin
-        if(_zz_181_)begin
-          _zz_171_ = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_171_ = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_172_ = 1'b0;
-    if(_zz_260_)begin
-      if(_zz_261_)begin
-        if(_zz_178_)begin
-          _zz_172_ = 1'b1;
-        end
-      end
-    end
-    if(_zz_262_)begin
-      if(_zz_263_)begin
-        if(_zz_180_)begin
-          _zz_172_ = 1'b1;
-        end
-      end
-    end
-    if(_zz_264_)begin
-      if(_zz_265_)begin
-        if(_zz_182_)begin
-          _zz_172_ = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_172_ = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_173_ = (_zz_61_ && writeBack_arbitration_isFiring);
-  assign _zz_177_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_178_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_179_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_180_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_181_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_182_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_183_ = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_183_ == (3'b000))) begin
-        _zz_184_ = execute_BranchPlugin_eq;
-    end else if((_zz_183_ == (3'b001))) begin
-        _zz_184_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_183_ & (3'b101)) == (3'b101)))) begin
-        _zz_184_ = (! execute_SRC_LESS);
-    end else begin
-        _zz_184_ = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_185_ = 1'b0;
+  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l200_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_185_ = 1'b1;
+      3'b001 : begin
+        _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_185_ = 1'b1;
+      3'b1?1 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
-        _zz_185_ = _zz_184_;
+        _zz_execute_BRANCH_DO = execute_SRC_LESS;
       end
     endcase
   end
 
-  assign _zz_42_ = _zz_185_;
-  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_186_ = _zz_330_[19];
-  always @ (*) begin
-    _zz_187_[10] = _zz_186_;
-    _zz_187_[9] = _zz_186_;
-    _zz_187_[8] = _zz_186_;
-    _zz_187_[7] = _zz_186_;
-    _zz_187_[6] = _zz_186_;
-    _zz_187_[5] = _zz_186_;
-    _zz_187_[4] = _zz_186_;
-    _zz_187_[3] = _zz_186_;
-    _zz_187_[2] = _zz_186_;
-    _zz_187_[1] = _zz_186_;
-    _zz_187_[0] = _zz_186_;
-  end
-
-  assign _zz_188_ = _zz_331_[11];
-  always @ (*) begin
-    _zz_189_[19] = _zz_188_;
-    _zz_189_[18] = _zz_188_;
-    _zz_189_[17] = _zz_188_;
-    _zz_189_[16] = _zz_188_;
-    _zz_189_[15] = _zz_188_;
-    _zz_189_[14] = _zz_188_;
-    _zz_189_[13] = _zz_188_;
-    _zz_189_[12] = _zz_188_;
-    _zz_189_[11] = _zz_188_;
-    _zz_189_[10] = _zz_188_;
-    _zz_189_[9] = _zz_188_;
-    _zz_189_[8] = _zz_188_;
-    _zz_189_[7] = _zz_188_;
-    _zz_189_[6] = _zz_188_;
-    _zz_189_[5] = _zz_188_;
-    _zz_189_[4] = _zz_188_;
-    _zz_189_[3] = _zz_188_;
-    _zz_189_[2] = _zz_188_;
-    _zz_189_[1] = _zz_188_;
-    _zz_189_[0] = _zz_188_;
-  end
-
-  assign _zz_190_ = _zz_332_[11];
-  always @ (*) begin
-    _zz_191_[18] = _zz_190_;
-    _zz_191_[17] = _zz_190_;
-    _zz_191_[16] = _zz_190_;
-    _zz_191_[15] = _zz_190_;
-    _zz_191_[14] = _zz_190_;
-    _zz_191_[13] = _zz_190_;
-    _zz_191_[12] = _zz_190_;
-    _zz_191_[11] = _zz_190_;
-    _zz_191_[10] = _zz_190_;
-    _zz_191_[9] = _zz_190_;
-    _zz_191_[8] = _zz_190_;
-    _zz_191_[7] = _zz_190_;
-    _zz_191_[6] = _zz_190_;
-    _zz_191_[5] = _zz_190_;
-    _zz_191_[4] = _zz_190_;
-    _zz_191_[3] = _zz_190_;
-    _zz_191_[2] = _zz_190_;
-    _zz_191_[1] = _zz_190_;
-    _zz_191_[0] = _zz_190_;
-  end
-
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_192_ = {{_zz_187_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+      `BranchCtrlEnum_binary_sequential_INC : begin
+        _zz_execute_BRANCH_DO_1 = 1'b0;
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_192_ = {_zz_189_,execute_INSTRUCTION[31 : 20]};
+      `BranchCtrlEnum_binary_sequential_JAL : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      `BranchCtrlEnum_binary_sequential_JALR : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
       end
       default : begin
-        _zz_192_ = {{_zz_191_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_execute_BRANCH_DO_1 = _zz_execute_BRANCH_DO;
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_192_;
-  assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
-  assign _zz_40_ = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign _zz_39_ = (execute_PC + (32'b00000000000000000000000000000100));
-  assign _zz_38_ = (decode_PC != execute_BRANCH_CALC);
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JALR) ? execute_RS1 : execute_PC);
+  assign _zz_execute_BRANCH_SRC22 = _zz__zz_execute_BRANCH_SRC22[19];
+  always @(*) begin
+    _zz_execute_BRANCH_SRC22_1[10] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[9] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[8] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[7] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[6] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[5] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[4] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[3] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[2] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[1] = _zz_execute_BRANCH_SRC22;
+    _zz_execute_BRANCH_SRC22_1[0] = _zz_execute_BRANCH_SRC22;
+  end
+
+  assign _zz_execute_BRANCH_SRC22_2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BRANCH_SRC22_3[19] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[18] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[17] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[16] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[15] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[14] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[13] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[12] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[11] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[10] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[9] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[8] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[7] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[6] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[5] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[4] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[3] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[2] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[1] = _zz_execute_BRANCH_SRC22_2;
+    _zz_execute_BRANCH_SRC22_3[0] = _zz_execute_BRANCH_SRC22_2;
+  end
+
+  assign _zz_execute_BRANCH_SRC22_4 = _zz__zz_execute_BRANCH_SRC22_4[11];
+  always @(*) begin
+    _zz_execute_BRANCH_SRC22_5[18] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[17] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[16] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[15] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[14] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[13] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[12] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[11] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[10] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[9] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[8] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[7] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[6] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[5] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[4] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[3] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[2] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[1] = _zz_execute_BRANCH_SRC22_4;
+    _zz_execute_BRANCH_SRC22_5[0] = _zz_execute_BRANCH_SRC22_4;
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_binary_sequential_JAL : begin
+        _zz_execute_BRANCH_SRC22_6 = {{_zz_execute_BRANCH_SRC22_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+      end
+      `BranchCtrlEnum_binary_sequential_JALR : begin
+        _zz_execute_BRANCH_SRC22_6 = {_zz_execute_BRANCH_SRC22_3,execute_INSTRUCTION[31 : 20]};
+      end
+      default : begin
+        _zz_execute_BRANCH_SRC22_6 = {{_zz_execute_BRANCH_SRC22_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+      end
+    endcase
+  end
+
+  assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BRANCH_SRC22);
   assign execute_BranchPlugin_predictionMissmatch = ((IBusCachedPlugin_fetchPrediction_cmd_hadBranch != execute_BRANCH_DO) || (execute_BRANCH_DO && execute_TARGET_MISSMATCH2));
   assign IBusCachedPlugin_fetchPrediction_rsp_wasRight = (! execute_BranchPlugin_predictionMissmatch);
   assign IBusCachedPlugin_fetchPrediction_rsp_finalPc = execute_BRANCH_CALC;
   assign IBusCachedPlugin_fetchPrediction_rsp_sourceLastWord = execute_PC;
-  assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && (! execute_arbitration_isStuckByOthers)) && execute_BranchPlugin_predictionMissmatch);
+  assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BranchPlugin_predictionMissmatch) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = (execute_BRANCH_DO ? execute_BRANCH_CALC : execute_NEXT_PC2);
-  always @ (*) begin
+  always @(*) begin
     BranchPlugin_branchExceptionPort_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && execute_BRANCH_CALC[1]);
-    if(1'b0)begin
+    if(when_BranchPlugin_l375) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
-    if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+  assign when_BranchPlugin_l375 = 1'b0;
+  always @(*) begin
+    CsrPlugin_privilege = 2'b11;
+    if(CsrPlugin_forceMachineWire) begin
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
-  assign CsrPlugin_misa_extensions = (26'b00000000000000000001000010);
-  assign _zz_193_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_194_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_195_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_196_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_197_ = _zz_333_[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_253_)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
-  always @ (*) begin
-    CsrPlugin_pipelineLiberator_done = ((! ({writeBack_arbitration_isValid,{memory_arbitration_isValid,execute_arbitration_isValid}} != (3'b000))) && IBusCachedPlugin_pcValids_3);
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+  assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
+    CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+  always @(*) begin
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -5011,8 +4104,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = (30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -5022,140 +4115,115 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign _zz_36_ = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == (5'b00000))) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == (5'b00000)))));
-  assign _zz_35_ = (decode_INSTRUCTION[13 : 7] != (7'b0100000));
-  assign execute_CsrPlugin_inWfi = 1'b0;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
-  always @ (*) begin
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    case(execute_CsrPlugin_csrAddress)
-      12'b101111000000 : begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
-      12'b001100000000 : begin
+    end
+    if(execute_CsrPlugin_csr_768) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_836) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_772) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
-      12'b001101000001 : begin
+    end
+    if(execute_CsrPlugin_csr_833) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
-      12'b001100000101 : begin
-        if(execute_CSR_WRITE_OPCODE)begin
-          execute_CsrPlugin_illegalAccess = 1'b0;
-        end
-      end
-      12'b001101000100 : begin
+    end
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
-      12'b110011000000 : begin
-        if(execute_CSR_READ_OPCODE)begin
-          execute_CsrPlugin_illegalAccess = 1'b0;
-        end
-      end
-      12'b001101000011 : begin
-        if(execute_CSR_READ_OPCODE)begin
-          execute_CsrPlugin_illegalAccess = 1'b0;
-        end
-      end
-      12'b111111000000 : begin
-        if(execute_CSR_READ_OPCODE)begin
-          execute_CsrPlugin_illegalAccess = 1'b0;
-        end
-      end
-      12'b001100000100 : begin
+    end
+    if(execute_CsrPlugin_csr_3008) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
-      12'b001101000010 : begin
-        if(execute_CSR_READ_OPCODE)begin
-          execute_CsrPlugin_illegalAccess = 1'b0;
-        end
-      end
-      default : begin
-      end
-    endcase
-    if((CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]))begin
+    end
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
-    execute_CsrPlugin_readData = (32'b00000000000000000000000000000000);
-    case(execute_CsrPlugin_csrAddress)
-      12'b101111000000 : begin
-        execute_CsrPlugin_readData[31 : 0] = _zz_205_;
-      end
-      12'b001100000000 : begin
-        execute_CsrPlugin_readData[12 : 11] = CsrPlugin_mstatus_MPP;
-        execute_CsrPlugin_readData[7 : 7] = CsrPlugin_mstatus_MPIE;
-        execute_CsrPlugin_readData[3 : 3] = CsrPlugin_mstatus_MIE;
-      end
-      12'b001101000001 : begin
-        execute_CsrPlugin_readData[31 : 0] = CsrPlugin_mepc;
-      end
-      12'b001100000101 : begin
-      end
-      12'b001101000100 : begin
-        execute_CsrPlugin_readData[11 : 11] = CsrPlugin_mip_MEIP;
-        execute_CsrPlugin_readData[7 : 7] = CsrPlugin_mip_MTIP;
-        execute_CsrPlugin_readData[3 : 3] = CsrPlugin_mip_MSIP;
-      end
-      12'b110011000000 : begin
-        execute_CsrPlugin_readData[13 : 0] = (14'b10000000000000);
-        execute_CsrPlugin_readData[25 : 20] = (6'b100000);
-      end
-      12'b001101000011 : begin
-        execute_CsrPlugin_readData[31 : 0] = CsrPlugin_mtval;
-      end
-      12'b111111000000 : begin
-        execute_CsrPlugin_readData[31 : 0] = _zz_206_;
-      end
-      12'b001100000100 : begin
-        execute_CsrPlugin_readData[11 : 11] = CsrPlugin_mie_MEIE;
-        execute_CsrPlugin_readData[7 : 7] = CsrPlugin_mie_MTIE;
-        execute_CsrPlugin_readData[3 : 3] = CsrPlugin_mie_MSIE;
-      end
-      12'b001101000010 : begin
-        execute_CsrPlugin_readData[31 : 31] = CsrPlugin_mcause_interrupt;
-        execute_CsrPlugin_readData[3 : 0] = CsrPlugin_mcause_exceptionCode;
-      end
-      default : begin
-      end
-    endcase
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  always @(*) begin
+    execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
+    if(when_CsrPlugin_l1297) begin
+      execute_CsrPlugin_writeInstruction = 1'b0;
+    end
   end
 
-  assign execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-  assign execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-  assign execute_CsrPlugin_writeEnable = ((execute_CsrPlugin_writeInstruction && (! execute_CsrPlugin_blockedBySideEffects)) && (! execute_arbitration_isStuckByOthers));
-  assign execute_CsrPlugin_readEnable = ((execute_CsrPlugin_readInstruction && (! execute_CsrPlugin_blockedBySideEffects)) && (! execute_arbitration_isStuckByOthers));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_275_)
+  always @(*) begin
+    execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
+    if(when_CsrPlugin_l1297) begin
+      execute_CsrPlugin_readInstruction = 1'b0;
+    end
+  end
+
+  assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
+  assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l200_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign execute_MulPlugin_a = execute_SRC1;
-  assign execute_MulPlugin_b = execute_SRC2;
-  always @ (*) begin
-    case(_zz_266_)
+  assign execute_MulPlugin_a = execute_RS1;
+  assign execute_MulPlugin_b = execute_RS2;
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5168,8 +4236,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_266_)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5188,85 +4256,156 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign _zz_32_ = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign _zz_31_ = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign _zz_30_ = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign _zz_29_ = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign _zz_28_ = ($signed(_zz_335_) + $signed(_zz_343_));
-  assign writeBack_MulPlugin_result = ($signed(_zz_344_) + $signed(_zz_345_));
-  always @ (*) begin
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
+  assign memory_DivPlugin_frontendOk = 1'b1;
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_248_)begin
-      if(_zz_254_)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_267_)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
-  assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == (6'b100001));
+  assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
-      memory_DivPlugin_div_counter_valueNext = (6'b000000);
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
+      memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_349_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
-      memory_DivPlugin_div_counter_valueNext = (6'b000000);
+    if(memory_DivPlugin_div_counter_willClear) begin
+      memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_198_ = memory_DivPlugin_rs1[31 : 0];
-  assign _zz_199_ = {memory_DivPlugin_accumulator[31 : 0],_zz_198_[31]};
-  assign _zz_200_ = (_zz_199_ - _zz_350_);
-  assign _zz_201_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_202_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_203_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_204_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_204_[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_206_ = (_zz_205_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_206_ != (32'b00000000000000000000000000000000));
-  assign _zz_27_ = decode_ALU_CTRL;
-  assign _zz_25_ = _zz_70_;
-  assign _zz_57_ = decode_to_execute_ALU_CTRL;
-  assign _zz_24_ = decode_SHIFT_CTRL;
-  assign _zz_21_ = execute_SHIFT_CTRL;
-  assign _zz_22_ = _zz_67_;
-  assign _zz_47_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_45_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_19_ = decode_BRANCH_CTRL;
-  assign _zz_17_ = _zz_84_;
-  assign _zz_41_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_16_ = decode_ENV_CTRL;
-  assign _zz_13_ = execute_ENV_CTRL;
-  assign _zz_11_ = memory_ENV_CTRL;
-  assign _zz_14_ = _zz_74_;
-  assign _zz_34_ = decode_to_execute_ENV_CTRL;
-  assign _zz_33_ = execute_to_memory_ENV_CTRL;
-  assign _zz_37_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_9_ = decode_SRC2_CTRL;
-  assign _zz_7_ = _zz_78_;
-  assign _zz_52_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_6_ = decode_SRC1_CTRL;
-  assign _zz_4_ = _zz_79_;
-  assign _zz_54_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_3_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_1_ = _zz_88_;
-  assign _zz_59_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign decode_arbitration_isFlushed = ({writeBack_arbitration_flushAll,{memory_arbitration_flushAll,{execute_arbitration_flushAll,decode_arbitration_flushAll}}} != (4'b0000));
-  assign execute_arbitration_isFlushed = ({writeBack_arbitration_flushAll,{memory_arbitration_flushAll,execute_arbitration_flushAll}} != (3'b000));
-  assign memory_arbitration_isFlushed = ({writeBack_arbitration_flushAll,memory_arbitration_flushAll} != (2'b00));
-  assign writeBack_arbitration_isFlushed = (writeBack_arbitration_flushAll != (1'b0));
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_35 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_39 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_40 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -5283,67 +4422,162 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  assign iBusWishbone_ADR = {_zz_369_,_zz_207_};
-  assign iBusWishbone_CTI = ((_zz_207_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[13 : 0] = 14'h2000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mip_MSIP;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mie_MSIE;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mepc;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 0] = CsrPlugin_mcause_exceptionCode;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = CsrPlugin_mtval;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | _zz_CsrPlugin_csrMapping_readDataInit_10);
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = (32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx);
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_268_)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_268_)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_208_;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_214_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_210_ = dBus_cmd_valid;
-  assign _zz_212_ = dBus_cmd_payload_wr;
-  assign _zz_213_ = (_zz_209_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_211_ && (_zz_212_ || _zz_213_));
-  assign dBusWishbone_ADR = ((_zz_214_ ? {{dBus_cmd_payload_address[31 : 5],_zz_209_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_214_ ? (_zz_213_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_212_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_212_;
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_211_ = (_zz_210_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_210_;
-  assign dBusWishbone_STB = _zz_210_;
-  assign dBus_rsp_valid = _zz_215_;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
+      IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
+      IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_115_ <= 1'b0;
-      _zz_121_ <= 1'b0;
-      _zz_123_ <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_injector_decodeRemoved <= 1'b0;
-      _zz_128_ <= 1'b0;
-      _zz_135_ <= 1'b0;
-      _zz_161_ <= 1'b1;
-      _zz_174_ <= 1'b0;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
+      IBusCachedPlugin_rspCounter <= 32'h0;
+      dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
+      DBusCachedPlugin_rspCounter <= 32'h0;
+      _zz_3 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -5352,141 +4586,164 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       CsrPlugin_interrupt_valid <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= (6'b000000);
-      _zz_205_ <= (32'b00000000000000000000000000000000);
+      memory_DivPlugin_div_counter_value <= 6'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= (32'b00000000000000000000000000000000);
-      memory_to_writeBack_INSTRUCTION <= (32'b00000000000000000000000000000000);
-      _zz_207_ <= (3'b000);
-      _zz_208_ <= 1'b0;
-      _zz_209_ <= (3'b000);
-      _zz_215_ <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_propagatePc)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
+        IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
+      end
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
+        IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
+      end
+      IBusCachedPlugin_fetchPc_booted <= 1'b1;
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_predictionPcLoad_valid)begin
-        IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      end
-      if(IBusCachedPlugin_jump_pcLoad_valid)begin
-        IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      end
-      if(_zz_258_)begin
+      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_samplePcNext)begin
+      if(when_Fetcher_l131_1) begin
+        IBusCachedPlugin_fetchPc_inc <= 1'b0;
+      end
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      _zz_115_ <= 1'b1;
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
-        _zz_121_ <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid <= 1'b0;
       end
-      if(_zz_119_)begin
-        _zz_121_ <= IBusCachedPlugin_iBusRsp_stages_0_output_valid;
+      if(IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_123_ <= IBusCachedPlugin_iBusRsp_stages_1_output_valid;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
-        _zz_123_ <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(decode_arbitration_removeIt)begin
-        IBusCachedPlugin_injector_decodeRemoved <= 1'b1;
+      if(iBus_rsp_valid) begin
+        IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if((IBusCachedPlugin_jump_pcLoad_valid || IBusCachedPlugin_fetcherflushIt))begin
-        IBusCachedPlugin_injector_decodeRemoved <= 1'b0;
+      if(dataCache_1_io_mem_cmd_valid) begin
+        dataCache_1_io_mem_cmd_rValid <= 1'b1;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        _zz_128_ <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_rValid <= 1'b0;
       end
-      if(_zz_269_)begin
-        _zz_128_ <= dataCache_1__io_mem_cmd_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        _zz_135_ <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dBus_rsp_valid) begin
+        DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_161_ <= 1'b0;
-      _zz_174_ <= _zz_173_;
-      if((! decode_arbitration_isStuck))begin
+      _zz_3 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_270_)begin
-        if(_zz_271_)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_272_)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_273_)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
+          CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
+        end
+        if(when_CsrPlugin_l980_1) begin
+          CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
+        end
+        if(when_CsrPlugin_l980_2) begin
+          CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
+        end
+      end
+      if(when_CsrPlugin_l985) begin
+        CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
+      end
+      if(CsrPlugin_interruptJump) begin
+        CsrPlugin_interrupt_valid <= 1'b0;
+      end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_255_)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5497,10 +4754,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_256_)begin
-        case(_zz_257_)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -5508,169 +4765,159 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= ({_zz_195_,{_zz_194_,_zz_193_}} != (3'b000));
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_44_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(execute_CsrPlugin_csrAddress)
-        12'b101111000000 : begin
-          if(execute_CsrPlugin_writeEnable)begin
-            _zz_205_ <= execute_CsrPlugin_writeData[31 : 0];
-          end
-        end
-        12'b001100000000 : begin
-          if(execute_CsrPlugin_writeEnable)begin
-            CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-            CsrPlugin_mstatus_MPIE <= _zz_363_[0];
-            CsrPlugin_mstatus_MIE <= _zz_364_[0];
-          end
-        end
-        12'b001101000001 : begin
-        end
-        12'b001100000101 : begin
-        end
-        12'b001101000100 : begin
-        end
-        12'b110011000000 : begin
-        end
-        12'b001101000011 : begin
-        end
-        12'b111111000000 : begin
-        end
-        12'b001100000100 : begin
-          if(execute_CsrPlugin_writeEnable)begin
-            CsrPlugin_mie_MEIE <= _zz_366_[0];
-            CsrPlugin_mie_MTIE <= _zz_367_[0];
-            CsrPlugin_mie_MSIE <= _zz_368_[0];
-          end
-        end
-        12'b001101000010 : begin
-        end
-        default : begin
-        end
-      endcase
-      if(_zz_268_)begin
-        if(iBusWishbone_ACK)begin
-          _zz_207_ <= (_zz_207_ + (3'b001));
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      _zz_208_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_210_ && _zz_211_))begin
-        _zz_209_ <= (_zz_209_ + (3'b001));
-        if(_zz_213_)begin
-          _zz_209_ <= (3'b000);
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      _zz_215_ <= ((_zz_210_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
+        end
+      end
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
+        end
+      end
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_124_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_0_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready)begin
-      IBusCachedPlugin_predictor_historyWriteLast_valid <= IBusCachedPlugin_predictor_historyWrite_valid;
-      IBusCachedPlugin_predictor_historyWriteLast_payload_address <= IBusCachedPlugin_predictor_historyWrite_payload_address;
-      IBusCachedPlugin_predictor_historyWriteLast_payload_data_source <= IBusCachedPlugin_predictor_historyWrite_payload_data_source;
-      IBusCachedPlugin_predictor_historyWriteLast_payload_data_branchWish <= IBusCachedPlugin_predictor_historyWrite_payload_data_branchWish;
-      IBusCachedPlugin_predictor_historyWriteLast_payload_data_target <= IBusCachedPlugin_predictor_historyWrite_payload_data_target;
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      IBusCachedPlugin_predictor_fetchContext_regNextWhen_hazard <= IBusCachedPlugin_predictor_fetchContext_hazard;
-      IBusCachedPlugin_predictor_fetchContext_regNextWhen_hit <= IBusCachedPlugin_predictor_fetchContext_hit;
-      IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_source <= IBusCachedPlugin_predictor_fetchContext_line_source;
-      IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_branchWish <= IBusCachedPlugin_predictor_fetchContext_line_branchWish;
-      IBusCachedPlugin_predictor_fetchContext_regNextWhen_line_target <= IBusCachedPlugin_predictor_fetchContext_line_target;
+    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+      IBusCachedPlugin_predictor_writeLast_valid <= IBusCachedPlugin_predictor_historyWriteDelayPatched_valid;
+      IBusCachedPlugin_predictor_writeLast_payload_address <= IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_address;
+      IBusCachedPlugin_predictor_writeLast_payload_data_source <= IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_source;
+      IBusCachedPlugin_predictor_writeLast_payload_data_branchWish <= IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_branchWish;
+      IBusCachedPlugin_predictor_writeLast_payload_data_target <= IBusCachedPlugin_predictor_historyWriteDelayPatched_payload_data_target;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_0_input_ready) begin
+      IBusCachedPlugin_predictor_buffer_pcCorrected <= IBusCachedPlugin_fetchPc_corrected;
+    end
+    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+      IBusCachedPlugin_predictor_line_source <= IBusCachedPlugin_predictor_buffer_line_source;
+      IBusCachedPlugin_predictor_line_branchWish <= IBusCachedPlugin_predictor_buffer_line_branchWish;
+      IBusCachedPlugin_predictor_line_target <= IBusCachedPlugin_predictor_buffer_line_target;
+    end
+    if(IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+      IBusCachedPlugin_predictor_buffer_hazard_regNextWhen <= IBusCachedPlugin_predictor_buffer_hazard;
+    end
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      IBusCachedPlugin_predictor_iBusRspContext_hazard <= IBusCachedPlugin_predictor_fetchContext_hazard;
+      IBusCachedPlugin_predictor_iBusRspContext_hit <= IBusCachedPlugin_predictor_fetchContext_hit;
+      IBusCachedPlugin_predictor_iBusRspContext_line_source <= IBusCachedPlugin_predictor_fetchContext_line_source;
+      IBusCachedPlugin_predictor_iBusRspContext_line_branchWish <= IBusCachedPlugin_predictor_fetchContext_line_branchWish;
+      IBusCachedPlugin_predictor_iBusRspContext_line_target <= IBusCachedPlugin_predictor_fetchContext_line_target;
+    end
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_cacheRspArbitration_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_269_)begin
-      _zz_129_ <= dataCache_1__io_mem_cmd_payload_wr;
-      _zz_130_ <= dataCache_1__io_mem_cmd_payload_address;
-      _zz_131_ <= dataCache_1__io_mem_cmd_payload_data;
-      _zz_132_ <= dataCache_1__io_mem_cmd_payload_mask;
-      _zz_133_ <= dataCache_1__io_mem_cmd_payload_length;
-      _zz_134_ <= dataCache_1__io_mem_cmd_payload_last;
+    if(dataCache_1_io_mem_cmd_ready) begin
+      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      _zz_136_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      _zz_137_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      _zz_138_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      _zz_139_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      _zz_140_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      _zz_141_ <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(_zz_173_)begin
-      _zz_175_ <= _zz_60_[11 : 7];
-      _zz_176_ <= _zz_92_;
-    end
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + (64'b0000000000000000000000000000000000000000000000000000000000000001));
-    if(writeBack_arbitration_isFiring)begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + (64'b0000000000000000000000000000000000000000000000000000000000000001));
+    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+    if(writeBack_arbitration_isFiring) begin
+      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_253_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_197_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_197_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_270_)begin
-      if(_zz_271_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_272_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(when_CsrPlugin_l952_1) begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_273_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(when_CsrPlugin_l952_2) begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_255_)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -5678,246 +4925,1528 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == (6'b100000)))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_248_)begin
-      if(_zz_254_)begin
-        memory_DivPlugin_rs1[31 : 0] <= _zz_351_[31:0];
-        memory_DivPlugin_accumulator[31 : 0] <= ((! _zz_200_[32]) ? _zz_352_ : _zz_353_);
-        if((memory_DivPlugin_div_counter_value == (6'b100000)))begin
-          memory_DivPlugin_div_result <= _zz_354_[31:0];
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
+        memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
+        memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_267_)begin
-      memory_DivPlugin_accumulator <= (65'b00000000000000000000000000000000000000000000000000000000000000000);
-      memory_DivPlugin_rs1 <= ((_zz_203_ ? (~ _zz_204_) : _zz_204_) + _zz_360_);
-      memory_DivPlugin_rs2 <= ((_zz_202_ ? (~ execute_RS2) : execute_RS2) + _zz_362_);
-      memory_DivPlugin_div_needRevert <= ((_zz_203_ ^ (_zz_202_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == (32'b00000000000000000000000000000000)) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+    if(when_MulDivIterativePlugin_l162) begin
+      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_26_;
+    if(when_Pipeline_l124) begin
+      decode_to_execute_PC <= decode_PC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    if(when_Pipeline_l124_2) begin
+      memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_23_;
+    if(when_Pipeline_l124_3) begin
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_20_;
+    if(when_Pipeline_l124_4) begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    if(when_Pipeline_l124_5) begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_43_;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_execute_to_memory_FORMAL_PC_NEXT;
+    end
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
+    end
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_PREDICTION_CONTEXT_hazard <= decode_PREDICTION_CONTEXT_hazard;
       decode_to_execute_PREDICTION_CONTEXT_hit <= decode_PREDICTION_CONTEXT_hit;
       decode_to_execute_PREDICTION_CONTEXT_line_source <= decode_PREDICTION_CONTEXT_line_source;
       decode_to_execute_PREDICTION_CONTEXT_line_branchWish <= decode_PREDICTION_CONTEXT_line_branchWish;
       decode_to_execute_PREDICTION_CONTEXT_line_target <= decode_PREDICTION_CONTEXT_line_target;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_11) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_18_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_15_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_12_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_10_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+    if(when_Pipeline_l124_13) begin
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+    if(when_Pipeline_l124_14) begin
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+    if(when_Pipeline_l124_15) begin
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+    end
+    if(when_Pipeline_l124_17) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
+    end
+    if(when_Pipeline_l124_18) begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if(when_Pipeline_l124_19) begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if(when_Pipeline_l124_20) begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_51_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_8_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    if(when_Pipeline_l124_24) begin
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+    if(when_Pipeline_l124_25) begin
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    if(when_Pipeline_l124_26) begin
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+    if(when_Pipeline_l124_28) begin
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_5_;
+    if(when_Pipeline_l124_29) begin
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    if(when_Pipeline_l124_30) begin
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_2_;
+    if(when_Pipeline_l124_32) begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_105_;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_104_;
+    if(when_Pipeline_l124_34) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
+    if(when_Pipeline_l124_35) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+    end
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if(when_Pipeline_l124_38) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+    end
+    if(when_Pipeline_l124_39) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+    end
+    if(when_Pipeline_l124_40) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+    end
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    case(execute_CsrPlugin_csrAddress)
-      12'b101111000000 : begin
+    if(when_Pipeline_l124_44) begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if(when_Pipeline_l124_45) begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if(when_Pipeline_l124_46) begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if(when_Pipeline_l124_47) begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if(when_Pipeline_l124_48) begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if(when_Pipeline_l124_49) begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if(when_Pipeline_l124_50) begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if(when_Pipeline_l124_51) begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if(when_Pipeline_l124_52) begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if(when_Pipeline_l124_53) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+    end
+    if(when_Pipeline_l124_54) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+    end
+    if(when_Pipeline_l124_55) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+    end
+    if(when_Pipeline_l124_56) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+    end
+    if(when_Pipeline_l124_57) begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if(when_Pipeline_l124_58) begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if(when_Pipeline_l124_59) begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_60) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if(when_Pipeline_l124_62) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+    end
+    if(when_CsrPlugin_l1264) begin
+      execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
+    end
+    if(when_CsrPlugin_l1264_1) begin
+      execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
+    end
+    if(when_CsrPlugin_l1264_2) begin
+      execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
+    end
+    if(when_CsrPlugin_l1264_3) begin
+      execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
+    end
+    if(when_CsrPlugin_l1264_4) begin
+      execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
+    end
+    if(when_CsrPlugin_l1264_5) begin
+      execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
+    end
+    if(when_CsrPlugin_l1264_6) begin
+      execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
+    end
+    if(when_CsrPlugin_l1264_7) begin
+      execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
+    end
+    if(when_CsrPlugin_l1264_8) begin
+      execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
+    end
+    if(when_CsrPlugin_l1264_9) begin
+      execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
+    end
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
-      12'b001100000000 : begin
+    end
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
-      12'b001101000001 : begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
-        end
+    end
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
-      12'b001100000101 : begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-          CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
-        end
-      end
-      12'b001101000100 : begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mip_MSIP <= _zz_365_[0];
-        end
-      end
-      12'b110011000000 : begin
-      end
-      12'b001101000011 : begin
-      end
-      12'b111111000000 : begin
-      end
-      12'b001100000100 : begin
-      end
-      12'b001101000010 : begin
-      end
-      default : begin
-      end
-    endcase
+    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
+
 endmodule
 
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output reg          io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_isLrsc,
+  input               io_cpu_execute_args_isAmo,
+  input               io_cpu_execute_args_amoCtrl_swap,
+  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output              io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_size,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [20:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [20:0]   _zz_ways_0_tags_port;
+  wire       [10:0]   _zz_stage0_dataColisions;
+  wire       [10:0]   _zz__zz_stageA_dataColisions;
+  wire       [31:0]   _zz_stageB_amo_addSub;
+  wire       [31:0]   _zz_stageB_amo_addSub_1;
+  wire       [31:0]   _zz_stageB_amo_addSub_2;
+  wire       [31:0]   _zz_stageB_amo_addSub_3;
+  wire       [31:0]   _zz_stageB_amo_addSub_4;
+  wire       [1:0]    _zz_stageB_amo_addSub_5;
+  wire       [1:0]    _zz_stageB_amo_addSub_6;
+  wire       [1:0]    _zz_stageB_amo_addSub_7;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [7:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [7:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [18:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [7:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [18:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [10:0]   dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [10:0]   dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [18:0]   ways_0_tagsReadRsp_address;
+  wire       [20:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  wire                io_mem_cmd_fire;
+  wire                when_DataCache_l678;
+  reg        [3:0]    _zz_stage0_mask;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                when_DataCache_l763;
+  reg                 stageA_request_wr;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_isLrsc;
+  reg                 stageA_request_isAmo;
+  reg                 stageA_request_amoCtrl_swap;
+  reg        [2:0]    stageA_request_amoCtrl_alu;
+  reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
+  reg        [3:0]    stageA_mask;
+  wire       [0:0]    stageA_wayHits;
+  wire                when_DataCache_l763_2;
+  reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_stageA_dataColisions;
+  wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
+  reg                 stageB_request_wr;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_isLrsc;
+  reg                 stageB_request_isAmo;
+  reg                 stageB_request_amoCtrl_swap;
+  reg        [2:0]    stageB_request_amoCtrl_alu;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [18:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
+  reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
+  reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_waitDone;
+  wire                stageB_flusher_hold;
+  reg        [8:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
+  reg                 stageB_flusher_start;
+  reg                 stageB_lrSc_reserved;
+  wire                when_DataCache_l866;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  reg        [31:0]   stageB_requestDataBypass;
+  wire                stageB_amo_compare;
+  wire                stageB_amo_unsigned;
+  wire       [31:0]   stageB_amo_addSub;
+  wire                stageB_amo_less;
+  wire                stageB_amo_selectRf;
+  wire       [2:0]    switch_Misc_l200;
+  reg        [31:0]   stageB_amo_result;
+  reg        [31:0]   stageB_amo_resultReg;
+  reg                 stageB_amo_internal_resultRegValid;
+  reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l984;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l997;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1010;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                when_DataCache_l1075;
+  wire                loader_done;
+  wire                when_DataCache_l1103;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
+  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
+
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[12 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[12 : 2] >>> 0);
+  assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
+  assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
+  assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
+  assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
+  assign _zz_stageB_amo_addSub_6 = 2'b01;
+  assign _zz_stageB_amo_addSub_7 = 2'b00;
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
+    end
+  end
+
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
+  end
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(when_DataCache_l637) begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    _zz_2 = 1'b0;
+    if(when_DataCache_l634) begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[20 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(when_DataCache_l656) begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    tagsReadCmd_payload = 8'bxxxxxxxx;
+    if(when_DataCache_l656) begin
+      tagsReadCmd_payload = io_cpu_execute_address[12 : 5];
+    end
+  end
+
+  always @(*) begin
+    dataReadCmd_valid = 1'b0;
+    if(when_DataCache_l656) begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    dataReadCmd_payload = 11'bxxxxxxxxxxx;
+    if(when_DataCache_l656) begin
+      dataReadCmd_payload = io_cpu_execute_address[12 : 2];
+    end
+  end
+
+  always @(*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+    if(when_DataCache_l1051) begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done) begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done) begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @(*) begin
+    tagsWriteCmd_payload_address = 8'bxxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[7:0];
+    end
+    if(loader_done) begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 5];
+    end
+  end
+
+  always @(*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done) begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @(*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done) begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 19'bxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 13];
+    end
+  end
+
+  always @(*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
+                dataWriteCmd_valid = 1'b0;
+              end
+            end
+            if(when_DataCache_l1010) begin
+              dataWriteCmd_valid = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(when_DataCache_l1051) begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(when_DataCache_l1075) begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache) begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(when_DataCache_l1075) begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @(*) begin
+    dataWriteCmd_payload_address = 11'bxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 2];
+    end
+    if(when_DataCache_l1075) begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[12 : 5],loader_counter_value};
+    end
+  end
+
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(when_DataCache_l1075) begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @(*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache) begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_when[0]) begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(when_DataCache_l1075) begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_stage0_mask = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 13] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if(when_DataCache_l1110) begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(when_DataCache_l1051) begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+          if(when_DataCache_l984) begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
+                io_cpu_writeBack_haltIt = 1'b1;
+              end
+            end
+            if(when_DataCache_l1010) begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(when_DataCache_l1051) begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  assign when_DataCache_l842 = (! stageB_flusher_counter[8]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[8]);
+  assign when_DataCache_l866 = ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc);
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  always @(*) begin
+    stageB_requestDataBypass = io_cpu_writeBack_storeData;
+    if(stageB_request_isAmo) begin
+      stageB_requestDataBypass[31 : 0] = stageB_amo_resultReg;
+    end
+  end
+
+  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
+  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
+  assign stageB_amo_addSub = _zz_stageB_amo_addSub;
+  assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
+  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
+  assign switch_Misc_l200 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  always @(*) begin
+    case(switch_Misc_l200)
+      3'b000 : begin
+        stageB_amo_result = stageB_amo_addSub;
+      end
+      3'b001 : begin
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] ^ stageB_dataMux[31 : 0]);
+      end
+      3'b010 : begin
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] | stageB_dataMux[31 : 0]);
+      end
+      3'b011 : begin
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] & stageB_dataMux[31 : 0]);
+      end
+      default : begin
+        stageB_amo_result = (stageB_amo_selectRf ? io_cpu_writeBack_storeData[31 : 0] : stageB_dataMux[31 : 0]);
+      end
+    endcase
+  end
+
+  always @(*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @(*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(when_DataCache_l1060) begin
+      io_cpu_redo = 1'b1;
+    end
+    if(when_DataCache_l1107) begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache) begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @(*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          io_mem_cmd_valid = (! memCmdSent);
+          if(when_DataCache_l984) begin
+            io_mem_cmd_valid = 1'b0;
+          end
+        end else begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
+              io_mem_cmd_valid = 1'b1;
+            end
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
+                io_mem_cmd_valid = 1'b0;
+              end
+            end
+            if(when_DataCache_l1005) begin
+              io_mem_cmd_valid = 1'b0;
+            end
+            if(when_DataCache_l1010) begin
+              io_mem_cmd_valid = 1'b0;
+            end
+          end else begin
+            if(when_DataCache_l1017) begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(when_DataCache_l1051) begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @(*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l984 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l997 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1010 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+  end
+
+  assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(when_DataCache_l1075) begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign io_cpu_execute_refilling = loader_valid;
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if(when_DataCache_l763) begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
+      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
+      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
+      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if(when_DataCache_l763_1) begin
+      stageA_mask <= stage0_mask;
+    end
+    if(when_DataCache_l763_2) begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if(when_DataCache_l763_3) begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if(when_DataCache_l814) begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_isLrsc <= stageA_request_isLrsc;
+      stageB_request_isAmo <= stageA_request_isAmo;
+      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
+      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(when_DataCache_l816) begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if(when_DataCache_l813) begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if(when_DataCache_l813_1) begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if(when_DataCache_l812) begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if(when_DataCache_l812_1) begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
+    end
+    if(when_DataCache_l812_3) begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if(when_DataCache_l812_4) begin
+      stageB_mask <= stageA_mask;
+    end
+    stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
+    stageB_amo_resultReg <= stageB_amo_result;
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @(posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 9'h0;
+      stageB_flusher_start <= 1'b1;
+      stageB_lrSc_reserved <= 1'b0;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_fire) begin
+        memCmdSent <= 1'b1;
+      end
+      if(when_DataCache_l678) begin
+        memCmdSent <= 1'b0;
+      end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 9'h001);
+        end
+      end
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 9'h0;
+      end
+      if(when_DataCache_l866) begin
+        stageB_lrSc_reserved <= (! stageB_request_wr);
+      end
+      if(when_DataCache_l1051) begin
+        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("ERROR writeBack stuck by another plugin is not allowed");
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid) begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill) begin
+        loader_killReg <= 1'b1;
+      end
+      if(when_DataCache_l1075) begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done) begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [20:0]   _zz_ways_0_tags_port1;
+  wire       [20:0]   _zz_ways_0_tags_port;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [8:0]    lineLoader_flushCounter;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
+  reg                 lineLoader_cmdSent;
+  wire                io_mem_cmd_fire;
+  wire                when_Utils_l357;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [7:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [18:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [10:0]   lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire                when_InstructionCache_l401;
+  wire       [10:0]   _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [7:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [18:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [20:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
+  reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:2047];
+  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
+    end
+  end
+
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid) begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid) begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @(*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(when_InstructionCache_l338) begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(when_InstructionCache_l342) begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush) begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[8]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if(when_Utils_l357) begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[8]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[8] ? lineLoader_address[12 : 5] : lineLoader_flushCounter[7 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[8];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 13];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[12 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[12 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[12 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[20 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 13]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @(posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire) begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire) begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid) begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush) begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(when_InstructionCache_l351) begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if(io_mem_cmd_fire) begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire) begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid) begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error) begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(when_InstructionCache_l338) begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 9'h001);
+    end
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[8];
+    if(when_InstructionCache_l351) begin
+      lineLoader_flushCounter <= 9'h0;
+    end
+    if(when_InstructionCache_l435) begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if(when_InstructionCache_l459) begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if(when_InstructionCache_l459_1) begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if(when_InstructionCache_l459_2) begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
+  end
+
+
+endmodule

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+val spinalVersion = "1.6.0"
 
 lazy val root = (project in file(".")).
   settings(
@@ -6,7 +7,11 @@ lazy val root = (project in file(".")).
       scalaVersion := "2.11.12",
       version      := "0.1.0-SNAPSHOT"
     )),
-    name := "VexRiscvOnWishbone"
+    name := "VexRiscvOnWishbone",
+
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.spinalhdl" % "spinalhdl-idsl-plugin_2.11" % spinalVersion)
+    )
   ).dependsOn(vexRiscv)
 
 lazy val vexRiscv = RootProject(file("ext/VexRiscv"))


### PR DESCRIPTION
# Summary
This PR bump VexRiscv to recent versions that implements FPU, and updated the generated verilog of the VexRiscv_IMA variant.

# Changed build files
`build.sbt`: Updated to build the scala project correctly. (See [post on gitter](https://gitter.im/SpinalHDL/VexRiscv?at=5ead64d422f9c45c2a65c516), worked immediately after updating `build.sbt` only)
